### PR TITLE
Replace no well supported Array.from

### DIFF
--- a/src/utils/all-affected.js
+++ b/src/utils/all-affected.js
@@ -19,7 +19,7 @@ const getTopParent = node => (node.parentNode ? getTopParent(node.parentNode) : 
 const getAllAffectedNodes = (node) => {
   const group = node.getAttribute(FOCUS_GROUP);
   if (group) {
-    return filterNested(Array.from(getTopParent(node).querySelectorAll(`[${FOCUS_GROUP}="${group}"]:not([${FOCUS_DISABLED}="disabled"])`)));
+    return filterNested([].call(getTopParent(node).querySelectorAll(`[${FOCUS_GROUP}="${group}"]:not([${FOCUS_DISABLED}="disabled"])`)));
   }
   return [node];
 };


### PR DESCRIPTION
Hi. `Array.from()` looks good, but [doesn’t have](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Array/from) IE 11 support.

Maybe I a few years later it will be safe to use it, but right now we have `Array.from is not a function` issues in our issue tracker.