### PR TITLE
change focus in frame detection to support cross origin iframes

### DIFF
--- a/src/focusInside.js
+++ b/src/focusInside.js
@@ -1,6 +1,6 @@
 import getAllAffectedNodes from './utils/all-affected';
 
-const focusInFrame = frame => frame.contentWindow.document.hasFocus();
+const focusInFrame = frame => frame === document.activeElement;
 
 const focusInsideIframe = topNode => (
   getAllAffectedNodes(topNode).reduce(


### PR DESCRIPTION
As we don't have access to contentWindow.document for cross-origin iframes, browsers will block this attempt and throw errors. We can check if the frame is activeElement on the document instead