### PR TITLE
fix: dataset of null error

### DIFF
--- a/src/focusMerge.js
+++ b/src/focusMerge.js
@@ -9,7 +9,7 @@ const findAutoFocused = autoFocusables => node => (
   autoFocusables.indexOf(node) >= 0
 );
 
-const isGuard = node => (node.dataset && node.dataset.focusGuard);
+const isGuard = node => (node && node.dataset && node.dataset.focusGuard);
 const notAGuard = node => !isGuard(node);
 
 export const newFocus = (innerNodes, outerNodes, activeElement, lastNode, autoFocused) => {


### PR DESCRIPTION
I'm using `react-focus-lock`. After the upgrade of `focus-lock` from 0.6.6 to 0.6.7 I started seeing the following error when running the CI:

```
08:53:50   return node.dataset && node.dataset.focusGuard;
08:53:50               ^
08:53:50
08:53:50 TypeError: Cannot read property 'dataset' of null
08:53:50     at isGuard
```

After some digging, I found this: https://github.com/theKashey/focus-lock/commit/421e8690d81dbeaaa43231a1be46bd4b235a84bf#diff-ba89194e8b70f259390f3e61e05a34e1R19

I ran the test suite and I'm seeing the following with my changes:

![Screen Shot 2020-04-24 at 11 13 53 AM](https://user-images.githubusercontent.com/8354571/80243814-ba3d3080-861c-11ea-8042-4f89c05996df.png)
