### PR TITLE
Fix error when focus within shadow dom

### DIFF
--- a/src/utils/DOMutils.js
+++ b/src/utils/DOMutils.js
@@ -20,7 +20,11 @@ export const isVisible = node => (
   ) ||
   (
     !isElementHidden(window.getComputedStyle(node, null)) &&
-    isVisible(node.parentNode)
+    isVisible(
+      node.parentNode.nodeType === node.DOCUMENT_FRAGMENT_NODE ?
+        node.parentNode.host :
+        node.parentNode,
+    )
   )
 );
 


### PR DESCRIPTION
- check if parent is document fragment
- if so, traverse to the host
- otherwise, continue as normal

fixes: #11 