### PR TITLE
Add focusOptions for sibling functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 npm-debug.log
 /dist/
 .DS_Store
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
 npm-debug.log
-/dist/
 .DS_Store
 .idea/

--- a/.size.json
+++ b/.size.json
@@ -2,6 +2,6 @@
   {
     "name": "dist/es2015/index.js",
     "passed": true,
-    "size": 2337
+    "size": 2346
   }
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [0.8.2](https://github.com/theKashey/focus-lock/compare/v0.8.1...v0.8.2) (2021-03-17)
+
 # [0.8.0](https://github.com/theKashey/focus-lock/compare/v0.7.0...v0.8.0) (2020-09-30)
 
 ### Bug Fixes

--- a/dist/es2015/constants.d.ts
+++ b/dist/es2015/constants.d.ts
@@ -1,0 +1,4 @@
+export declare const FOCUS_GROUP = 'data-focus-lock';
+export declare const FOCUS_DISABLED = 'data-focus-lock-disabled';
+export declare const FOCUS_ALLOW = 'data-no-focus-lock';
+export declare const FOCUS_AUTO = 'data-autofocus-inside';

--- a/dist/es2015/constants.js
+++ b/dist/es2015/constants.js
@@ -1,0 +1,4 @@
+export var FOCUS_GROUP = 'data-focus-lock';
+export var FOCUS_DISABLED = 'data-focus-lock-disabled';
+export var FOCUS_ALLOW = 'data-no-focus-lock';
+export var FOCUS_AUTO = 'data-autofocus-inside';

--- a/dist/es2015/focusInside.d.ts
+++ b/dist/es2015/focusInside.d.ts
@@ -1,0 +1,1 @@
+export declare const focusInside: (topNode: HTMLElement | HTMLElement[]) => boolean;

--- a/dist/es2015/focusInside.js
+++ b/dist/es2015/focusInside.js
@@ -1,0 +1,21 @@
+import { getAllAffectedNodes } from './utils/all-affected';
+import { toArray } from './utils/array';
+var focusInFrame = function(frame) {
+  return frame === document.activeElement;
+};
+var focusInsideIframe = function(topNode) {
+  return Boolean(
+    toArray(topNode.querySelectorAll('iframe')).some(function(node) {
+      return focusInFrame(node);
+    })
+  );
+};
+export var focusInside = function(topNode) {
+  var activeElement = document && document.activeElement;
+  if (!activeElement || (activeElement.dataset && activeElement.dataset.focusGuard)) {
+    return false;
+  }
+  return getAllAffectedNodes(topNode).reduce(function(result, node) {
+    return result || node.contains(activeElement) || focusInsideIframe(node);
+  }, false);
+};

--- a/dist/es2015/focusIsHidden.d.ts
+++ b/dist/es2015/focusIsHidden.d.ts
@@ -1,0 +1,1 @@
+export declare const focusIsHidden: () => boolean;

--- a/dist/es2015/focusIsHidden.js
+++ b/dist/es2015/focusIsHidden.js
@@ -1,0 +1,10 @@
+import { FOCUS_ALLOW } from './constants';
+import { toArray } from './utils/array';
+export var focusIsHidden = function() {
+  return (
+    document &&
+    toArray(document.querySelectorAll('[' + FOCUS_ALLOW + ']')).some(function(node) {
+      return node.contains(document.activeElement);
+    })
+  );
+};

--- a/dist/es2015/focusMerge.d.ts
+++ b/dist/es2015/focusMerge.d.ts
@@ -1,0 +1,10 @@
+import { NodeIndex } from './utils/tabOrder';
+export declare const getFocusMerge: (
+  topNode: HTMLElement | HTMLElement[],
+  lastNode: HTMLInputElement | null
+) =>
+  | NodeIndex
+  | {
+      node: HTMLInputElement;
+    }
+  | undefined;

--- a/dist/es2015/focusMerge.js
+++ b/dist/es2015/focusMerge.js
@@ -1,0 +1,63 @@
+import { NEW_FOCUS, newFocus } from './solver';
+import { getAllAffectedNodes } from './utils/all-affected';
+import { getAllTabbableNodes, getTabbableNodes } from './utils/DOMutils';
+import { pickFirstFocus } from './utils/firstFocus';
+import { isDefined, isNotAGuard } from './utils/is';
+import { allParentAutofocusables, getTopCommonParent } from './utils/parenting';
+var findAutoFocused = function(autoFocusables) {
+  return function(node) {
+    return node.autofocus || (node.dataset && !!node.dataset.autofocus) || autoFocusables.indexOf(node) >= 0;
+  };
+};
+var reorderNodes = function(srcNodes, dstNodes) {
+  var remap = new Map();
+  dstNodes.forEach(function(entity) {
+    return remap.set(entity.node, entity);
+  });
+  return srcNodes
+    .map(function(node) {
+      return remap.get(node);
+    })
+    .filter(isDefined);
+};
+export var getFocusMerge = function(topNode, lastNode) {
+  var activeElement = document && document.activeElement;
+  var entries = getAllAffectedNodes(topNode).filter(isNotAGuard);
+  var commonParent = getTopCommonParent(activeElement || topNode, topNode, entries);
+  var anyFocusable = getAllTabbableNodes(entries);
+  var innerElements = getTabbableNodes(entries).filter(function(_a) {
+    var node = _a.node;
+    return isNotAGuard(node);
+  });
+  if (!innerElements[0]) {
+    innerElements = anyFocusable;
+    if (!innerElements[0]) {
+      return undefined;
+    }
+  }
+  var outerNodes = getAllTabbableNodes([commonParent]).map(function(_a) {
+    var node = _a.node;
+    return node;
+  });
+  var orderedInnerElements = reorderNodes(outerNodes, innerElements);
+  var innerNodes = orderedInnerElements.map(function(_a) {
+    var node = _a.node;
+    return node;
+  });
+  var newId = newFocus(innerNodes, outerNodes, activeElement, lastNode);
+  if (newId === NEW_FOCUS) {
+    var autoFocusable = anyFocusable
+      .map(function(_a) {
+        var node = _a.node;
+        return node;
+      })
+      .filter(findAutoFocused(allParentAutofocusables(entries)));
+    return {
+      node: autoFocusable && autoFocusable.length ? pickFirstFocus(autoFocusable) : pickFirstFocus(innerNodes),
+    };
+  }
+  if (newId === undefined) {
+    return newId;
+  }
+  return orderedInnerElements[newId];
+};

--- a/dist/es2015/focusables.d.ts
+++ b/dist/es2015/focusables.d.ts
@@ -1,0 +1,8 @@
+interface FocusableIn {
+  node: HTMLElement;
+  index: number;
+  lockItem: boolean;
+  guard: boolean;
+}
+export declare const getFocusabledIn: (topNode: HTMLElement) => FocusableIn[];
+export {};

--- a/dist/es2015/focusables.js
+++ b/dist/es2015/focusables.js
@@ -1,0 +1,28 @@
+import { getAllAffectedNodes } from './utils/all-affected';
+import { getTabbableNodes } from './utils/DOMutils';
+import { isGuard, isNotAGuard } from './utils/is';
+import { getTopCommonParent } from './utils/parenting';
+export var getFocusabledIn = function(topNode) {
+  var entries = getAllAffectedNodes(topNode).filter(isNotAGuard);
+  var commonParent = getTopCommonParent(topNode, topNode, entries);
+  var outerNodes = getTabbableNodes([commonParent], true);
+  var innerElements = getTabbableNodes(entries)
+    .filter(function(_a) {
+      var node = _a.node;
+      return isNotAGuard(node);
+    })
+    .map(function(_a) {
+      var node = _a.node;
+      return node;
+    });
+  return outerNodes.map(function(_a) {
+    var node = _a.node,
+      index = _a.index;
+    return {
+      node: node,
+      index: index,
+      lockItem: innerElements.indexOf(node) >= 0,
+      guard: isGuard(node),
+    };
+  });
+};

--- a/dist/es2015/index.d.ts
+++ b/dist/es2015/index.d.ts
@@ -1,0 +1,21 @@
+import * as constants from './constants';
+import { getFocusabledIn } from './focusables';
+import { focusInside } from './focusInside';
+import { focusIsHidden } from './focusIsHidden';
+import { getFocusMerge as focusMerge } from './focusMerge';
+import { setFocus } from './setFocus';
+import { focusNextElement, focusPrevElement } from './sibling';
+import tabHook from './tabHook';
+import { getAllAffectedNodes } from './utils/all-affected';
+export {
+  tabHook,
+  focusInside,
+  focusIsHidden,
+  focusMerge,
+  getFocusabledIn,
+  constants,
+  getAllAffectedNodes,
+  focusNextElement,
+  focusPrevElement,
+};
+export default setFocus;

--- a/dist/es2015/index.js
+++ b/dist/es2015/index.js
@@ -1,0 +1,21 @@
+import * as constants from './constants';
+import { getFocusabledIn } from './focusables';
+import { focusInside } from './focusInside';
+import { focusIsHidden } from './focusIsHidden';
+import { getFocusMerge as focusMerge } from './focusMerge';
+import { setFocus } from './setFocus';
+import { focusNextElement, focusPrevElement } from './sibling';
+import tabHook from './tabHook';
+import { getAllAffectedNodes } from './utils/all-affected';
+export {
+  tabHook,
+  focusInside,
+  focusIsHidden,
+  focusMerge,
+  getFocusabledIn,
+  constants,
+  getAllAffectedNodes,
+  focusNextElement,
+  focusPrevElement,
+};
+export default setFocus;

--- a/dist/es2015/setFocus.d.ts
+++ b/dist/es2015/setFocus.d.ts
@@ -1,0 +1,2 @@
+export declare const focusOn: (target: HTMLInputElement | HTMLFrameElement) => void;
+export declare const setFocus: (topNode: HTMLElement, lastNode: HTMLInputElement) => void;

--- a/dist/es2015/setFocus.js
+++ b/dist/es2015/setFocus.js
@@ -1,0 +1,31 @@
+import { getFocusMerge } from './focusMerge';
+export var focusOn = function(target) {
+  target.focus();
+  if ('contentWindow' in target && target.contentWindow) {
+    target.contentWindow.focus();
+  }
+};
+var guardCount = 0;
+var lockDisabled = false;
+export var setFocus = function(topNode, lastNode) {
+  var focusable = getFocusMerge(topNode, lastNode);
+  if (lockDisabled) {
+    return;
+  }
+  if (focusable) {
+    if (guardCount > 2) {
+      console.error(
+        'FocusLock: focus-fighting detected. Only one focus management system could be active. ' +
+          'See https://github.com/theKashey/focus-lock/#focus-fighting'
+      );
+      lockDisabled = true;
+      setTimeout(function() {
+        lockDisabled = false;
+      }, 1);
+      return;
+    }
+    guardCount++;
+    focusOn(focusable.node);
+    guardCount--;
+  }
+};

--- a/dist/es2015/sibling.d.ts
+++ b/dist/es2015/sibling.d.ts
@@ -1,0 +1,8 @@
+interface FocusNextOptions {
+  scope?: HTMLElement | HTMLDocument;
+  cycle?: boolean;
+  focusOptions?: FocusOptions;
+}
+export declare const focusNextElement: (baseElement: Element, options?: FocusNextOptions) => void;
+export declare const focusPrevElement: (baseElement: Element, options?: FocusNextOptions) => void;
+export {};

--- a/dist/es2015/sibling.js
+++ b/dist/es2015/sibling.js
@@ -1,0 +1,59 @@
+import { getTabbableNodes } from './utils/DOMutils';
+var getRelativeFocusable = function(element, scope) {
+  if (!element || !scope || !scope.contains(element)) {
+    return {};
+  }
+  var focusables = getTabbableNodes([scope]);
+  var current = focusables.findIndex(function(_a) {
+    var node = _a.node;
+    return node === element;
+  });
+  if (current === -1) {
+    return {};
+  }
+  return {
+    prev: focusables[current - 1],
+    next: focusables[current + 1],
+    first: focusables[0],
+    last: focusables[focusables.length - 1],
+  };
+};
+var defaultOptions = function(options) {
+  return Object.assign(
+    {
+      scope: document.body,
+      cycle: true,
+    },
+    options
+  );
+};
+export var focusNextElement = function(baseElement, options) {
+  if (options === void 0) {
+    options = {};
+  }
+  var _a = defaultOptions(options),
+    scope = _a.scope,
+    cycle = _a.cycle;
+  var _b = getRelativeFocusable(baseElement, scope),
+    next = _b.next,
+    first = _b.first;
+  var newTarget = next || (cycle && first);
+  if (newTarget) {
+    newTarget.node.focus(options.focusOptions);
+  }
+};
+export var focusPrevElement = function(baseElement, options) {
+  if (options === void 0) {
+    options = {};
+  }
+  var _a = defaultOptions(options),
+    scope = _a.scope,
+    cycle = _a.cycle;
+  var _b = getRelativeFocusable(baseElement, scope),
+    prev = _b.prev,
+    last = _b.last;
+  var newTarget = prev || (cycle && last);
+  if (newTarget) {
+    newTarget.node.focus(options.focusOptions);
+  }
+};

--- a/dist/es2015/solver.d.ts
+++ b/dist/es2015/solver.d.ts
@@ -1,0 +1,7 @@
+export declare const NEW_FOCUS = 'NEW_FOCUS';
+export declare const newFocus: (
+  innerNodes: HTMLInputElement[],
+  outerNodes: HTMLInputElement[],
+  activeElement: HTMLInputElement,
+  lastNode: HTMLInputElement | null
+) => number | undefined | typeof NEW_FOCUS;

--- a/dist/es2015/solver.js
+++ b/dist/es2015/solver.js
@@ -1,0 +1,52 @@
+import { correctNodes } from './utils/correctFocus';
+import { pickFocusable } from './utils/firstFocus';
+import { isGuard } from './utils/is';
+export var NEW_FOCUS = 'NEW_FOCUS';
+export var newFocus = function(innerNodes, outerNodes, activeElement, lastNode) {
+  var cnt = innerNodes.length;
+  var firstFocus = innerNodes[0];
+  var lastFocus = innerNodes[cnt - 1];
+  var isOnGuard = isGuard(activeElement);
+  if (innerNodes.indexOf(activeElement) >= 0) {
+    return undefined;
+  }
+  var activeIndex = outerNodes.indexOf(activeElement);
+  var lastIndex = lastNode ? outerNodes.indexOf(lastNode) : activeIndex;
+  var lastNodeInside = lastNode ? innerNodes.indexOf(lastNode) : -1;
+  var indexDiff = activeIndex - lastIndex;
+  var firstNodeIndex = outerNodes.indexOf(firstFocus);
+  var lastNodeIndex = outerNodes.indexOf(lastFocus);
+  var correctedNodes = correctNodes(outerNodes);
+  var correctedIndexDiff =
+    correctedNodes.indexOf(activeElement) - (lastNode ? correctedNodes.indexOf(lastNode) : activeIndex);
+  var returnFirstNode = pickFocusable(innerNodes, 0);
+  var returnLastNode = pickFocusable(innerNodes, cnt - 1);
+  if (activeIndex === -1 || lastNodeInside === -1) {
+    return NEW_FOCUS;
+  }
+  if (!indexDiff && lastNodeInside >= 0) {
+    return lastNodeInside;
+  }
+  if (activeIndex <= firstNodeIndex && isOnGuard && Math.abs(indexDiff) > 1) {
+    return returnLastNode;
+  }
+  if (activeIndex >= lastNodeIndex && isOnGuard && Math.abs(indexDiff) > 1) {
+    return returnFirstNode;
+  }
+  if (indexDiff && Math.abs(correctedIndexDiff) > 1) {
+    return lastNodeInside;
+  }
+  if (activeIndex <= firstNodeIndex) {
+    return returnLastNode;
+  }
+  if (activeIndex > lastNodeIndex) {
+    return returnFirstNode;
+  }
+  if (indexDiff) {
+    if (Math.abs(indexDiff) > 1) {
+      return lastNodeInside;
+    }
+    return (cnt + lastNodeInside + indexDiff) % cnt;
+  }
+  return undefined;
+};

--- a/dist/es2015/tabHook.d.ts
+++ b/dist/es2015/tabHook.d.ts
@@ -1,0 +1,5 @@
+declare const _default: {
+  attach(): void;
+  detach(): void;
+};
+export default _default;

--- a/dist/es2015/tabHook.js
+++ b/dist/es2015/tabHook.js
@@ -1,0 +1,4 @@
+export default {
+  attach: function() {},
+  detach: function() {},
+};

--- a/dist/es2015/utils/DOMutils.d.ts
+++ b/dist/es2015/utils/DOMutils.d.ts
@@ -1,0 +1,5 @@
+import { NodeIndex } from './tabOrder';
+export declare const filterFocusable: (nodes: HTMLInputElement[]) => HTMLInputElement[];
+export declare const getTabbableNodes: (topNodes: HTMLElement[], withGuards?: boolean | undefined) => NodeIndex[];
+export declare const getAllTabbableNodes: (topNodes: HTMLElement[]) => NodeIndex[];
+export declare const parentAutofocusables: (topNode: HTMLElement) => HTMLInputElement[];

--- a/dist/es2015/utils/DOMutils.js
+++ b/dist/es2015/utils/DOMutils.js
@@ -1,0 +1,22 @@
+import { toArray } from './array';
+import { isVisible, notHiddenInput } from './is';
+import { orderByTabIndex } from './tabOrder';
+import { getFocusables, getParentAutofocusables } from './tabUtils';
+export var filterFocusable = function(nodes) {
+  return toArray(nodes)
+    .filter(function(node) {
+      return isVisible(node);
+    })
+    .filter(function(node) {
+      return notHiddenInput(node);
+    });
+};
+export var getTabbableNodes = function(topNodes, withGuards) {
+  return orderByTabIndex(filterFocusable(getFocusables(topNodes, withGuards)), true, withGuards);
+};
+export var getAllTabbableNodes = function(topNodes) {
+  return orderByTabIndex(filterFocusable(getFocusables(topNodes)), false);
+};
+export var parentAutofocusables = function(topNode) {
+  return filterFocusable(getParentAutofocusables(topNode));
+};

--- a/dist/es2015/utils/all-affected.d.ts
+++ b/dist/es2015/utils/all-affected.d.ts
@@ -1,0 +1,1 @@
+export declare const getAllAffectedNodes: (node: HTMLElement | HTMLElement[]) => HTMLInputElement[];

--- a/dist/es2015/utils/all-affected.js
+++ b/dist/es2015/utils/all-affected.js
@@ -1,0 +1,42 @@
+import { FOCUS_DISABLED, FOCUS_GROUP } from '../constants';
+import { asArray, toArray } from './array';
+var filterNested = function(nodes) {
+  var contained = new Set();
+  var l = nodes.length;
+  for (var i = 0; i < l; i += 1) {
+    for (var j = i + 1; j < l; j += 1) {
+      var position = nodes[i].compareDocumentPosition(nodes[j]);
+      if ((position & Node.DOCUMENT_POSITION_CONTAINED_BY) > 0) {
+        contained.add(j);
+      }
+      if ((position & Node.DOCUMENT_POSITION_CONTAINS) > 0) {
+        contained.add(i);
+      }
+    }
+  }
+  return nodes.filter(function(_, index) {
+    return !contained.has(index);
+  });
+};
+var getTopParent = function(node) {
+  return node.parentNode ? getTopParent(node.parentNode) : node;
+};
+export var getAllAffectedNodes = function(node) {
+  var nodes = asArray(node);
+  return nodes.filter(Boolean).reduce(function(acc, currentNode) {
+    var group = currentNode.getAttribute(FOCUS_GROUP);
+    acc.push.apply(
+      acc,
+      group
+        ? filterNested(
+            toArray(
+              getTopParent(currentNode).querySelectorAll(
+                '[' + FOCUS_GROUP + '="' + group + '"]:not([' + FOCUS_DISABLED + '="disabled"])'
+              )
+            )
+          )
+        : [currentNode]
+    );
+    return acc;
+  }, []);
+};

--- a/dist/es2015/utils/array.d.ts
+++ b/dist/es2015/utils/array.d.ts
@@ -1,0 +1,7 @@
+interface ListOf<TNode> {
+  length: number;
+  [index: number]: TNode;
+}
+export declare const toArray: <T>(a: ListOf<T> | T[]) => T[];
+export declare const asArray: <T>(a: T | T[]) => T[];
+export {};

--- a/dist/es2015/utils/array.js
+++ b/dist/es2015/utils/array.js
@@ -1,0 +1,10 @@
+export var toArray = function(a) {
+  var ret = Array(a.length);
+  for (var i = 0; i < a.length; ++i) {
+    ret[i] = a[i];
+  }
+  return ret;
+};
+export var asArray = function(a) {
+  return Array.isArray(a) ? a : [a];
+};

--- a/dist/es2015/utils/correctFocus.d.ts
+++ b/dist/es2015/utils/correctFocus.d.ts
@@ -1,0 +1,2 @@
+export declare const correctNode: (node: HTMLInputElement, nodes: HTMLInputElement[]) => HTMLInputElement;
+export declare const correctNodes: (nodes: HTMLInputElement[]) => HTMLInputElement[];

--- a/dist/es2015/utils/correctFocus.js
+++ b/dist/es2015/utils/correctFocus.js
@@ -1,0 +1,30 @@
+var isRadio = function(node) {
+  return node.tagName === 'INPUT' && node.type === 'radio';
+};
+var findSelectedRadio = function(node, nodes) {
+  return (
+    nodes
+      .filter(isRadio)
+      .filter(function(el) {
+        return el.name === node.name;
+      })
+      .filter(function(el) {
+        return el.checked;
+      })[0] || node
+  );
+};
+export var correctNode = function(node, nodes) {
+  if (isRadio(node) && node.name) {
+    return findSelectedRadio(node, nodes);
+  }
+  return node;
+};
+export var correctNodes = function(nodes) {
+  var resultSet = new Set();
+  nodes.forEach(function(node) {
+    return resultSet.add(correctNode(node, nodes));
+  });
+  return nodes.filter(function(node) {
+    return resultSet.has(node);
+  });
+};

--- a/dist/es2015/utils/firstFocus.d.ts
+++ b/dist/es2015/utils/firstFocus.d.ts
@@ -1,0 +1,2 @@
+export declare const pickFirstFocus: (nodes: HTMLInputElement[]) => HTMLInputElement;
+export declare const pickFocusable: (nodes: HTMLInputElement[], index: number) => number;

--- a/dist/es2015/utils/firstFocus.js
+++ b/dist/es2015/utils/firstFocus.js
@@ -1,0 +1,13 @@
+import { correctNode } from './correctFocus';
+export var pickFirstFocus = function(nodes) {
+  if (nodes[0] && nodes.length > 1) {
+    return correctNode(nodes[0], nodes);
+  }
+  return nodes[0];
+};
+export var pickFocusable = function(nodes, index) {
+  if (nodes.length > 1) {
+    return nodes.indexOf(correctNode(nodes[index], nodes));
+  }
+  return index;
+};

--- a/dist/es2015/utils/is.d.ts
+++ b/dist/es2015/utils/is.d.ts
@@ -1,0 +1,5 @@
+export declare const isVisible: (node: HTMLElement | undefined) => boolean;
+export declare const notHiddenInput: (node: HTMLInputElement) => boolean;
+export declare const isGuard: (node: HTMLElement) => boolean;
+export declare const isNotAGuard: (node: HTMLElement) => boolean;
+export declare const isDefined: <T>(x: T | null | undefined) => x is T;

--- a/dist/es2015/utils/is.js
+++ b/dist/es2015/utils/is.js
@@ -1,0 +1,33 @@
+var isElementHidden = function(computedStyle) {
+  if (!computedStyle || !computedStyle.getPropertyValue) {
+    return false;
+  }
+  return (
+    computedStyle.getPropertyValue('display') === 'none' || computedStyle.getPropertyValue('visibility') === 'hidden'
+  );
+};
+export var isVisible = function(node) {
+  return (
+    !node ||
+    node === document ||
+    (node && node.nodeType === Node.DOCUMENT_NODE) ||
+    (!isElementHidden(window.getComputedStyle(node, null)) &&
+      isVisible(
+        node.parentNode && node.parentNode.nodeType === Node.DOCUMENT_FRAGMENT_NODE
+          ? node.parentNode.host
+          : node.parentNode
+      ))
+  );
+};
+export var notHiddenInput = function(node) {
+  return !((node.tagName === 'INPUT' || node.tagName === 'BUTTON') && (node.type === 'hidden' || node.disabled));
+};
+export var isGuard = function(node) {
+  return Boolean(node && node.dataset && node.dataset.focusGuard);
+};
+export var isNotAGuard = function(node) {
+  return !isGuard(node);
+};
+export var isDefined = function(x) {
+  return Boolean(x);
+};

--- a/dist/es2015/utils/parenting.d.ts
+++ b/dist/es2015/utils/parenting.d.ts
@@ -1,0 +1,7 @@
+export declare const getCommonParent: (nodeA: HTMLElement, nodeB: HTMLElement) => false | HTMLElement;
+export declare const getTopCommonParent: (
+  baseActiveElement: HTMLElement,
+  leftEntry: HTMLElement | HTMLElement[],
+  rightEntries: HTMLElement[]
+) => HTMLElement;
+export declare const allParentAutofocusables: (entries: HTMLElement[]) => HTMLInputElement[];

--- a/dist/es2015/utils/parenting.js
+++ b/dist/es2015/utils/parenting.js
@@ -1,0 +1,48 @@
+import { asArray } from './array';
+import { parentAutofocusables } from './DOMutils';
+var getParents = function(node, parents) {
+  if (parents === void 0) {
+    parents = [];
+  }
+  parents.push(node);
+  if (node.parentNode) {
+    getParents(node.parentNode, parents);
+  }
+  return parents;
+};
+export var getCommonParent = function(nodeA, nodeB) {
+  var parentsA = getParents(nodeA);
+  var parentsB = getParents(nodeB);
+  for (var i = 0; i < parentsA.length; i += 1) {
+    var currentParent = parentsA[i];
+    if (parentsB.indexOf(currentParent) >= 0) {
+      return currentParent;
+    }
+  }
+  return false;
+};
+export var getTopCommonParent = function(baseActiveElement, leftEntry, rightEntries) {
+  var activeElements = asArray(baseActiveElement);
+  var leftEntries = asArray(leftEntry);
+  var activeElement = activeElements[0];
+  var topCommon = false;
+  leftEntries.filter(Boolean).forEach(function(entry) {
+    topCommon = getCommonParent(topCommon || entry, entry) || topCommon;
+    rightEntries.filter(Boolean).forEach(function(subEntry) {
+      var common = getCommonParent(activeElement, subEntry);
+      if (common) {
+        if (!topCommon || common.contains(topCommon)) {
+          topCommon = common;
+        } else {
+          topCommon = getCommonParent(common, topCommon);
+        }
+      }
+    });
+  });
+  return topCommon;
+};
+export var allParentAutofocusables = function(entries) {
+  return entries.reduce(function(acc, node) {
+    return acc.concat(parentAutofocusables(node));
+  }, []);
+};

--- a/dist/es2015/utils/tabOrder.d.ts
+++ b/dist/es2015/utils/tabOrder.d.ts
@@ -1,0 +1,11 @@
+export interface NodeIndex {
+  node: HTMLInputElement;
+  tabIndex: number;
+  index: number;
+}
+export declare const tabSort: (a: NodeIndex, b: NodeIndex) => number;
+export declare const orderByTabIndex: (
+  nodes: HTMLInputElement[],
+  filterNegative: boolean,
+  keepGuards?: boolean | undefined
+) => NodeIndex[];

--- a/dist/es2015/utils/tabOrder.js
+++ b/dist/es2015/utils/tabOrder.js
@@ -1,0 +1,28 @@
+import { toArray } from './array';
+export var tabSort = function(a, b) {
+  var tabDiff = a.tabIndex - b.tabIndex;
+  var indexDiff = a.index - b.index;
+  if (tabDiff) {
+    if (!a.tabIndex) {
+      return 1;
+    }
+    if (!b.tabIndex) {
+      return -1;
+    }
+  }
+  return tabDiff || indexDiff;
+};
+export var orderByTabIndex = function(nodes, filterNegative, keepGuards) {
+  return toArray(nodes)
+    .map(function(node, index) {
+      return {
+        node: node,
+        index: index,
+        tabIndex: keepGuards && node.tabIndex === -1 ? ((node.dataset || {}).focusGuard ? 0 : -1) : node.tabIndex,
+      };
+    })
+    .filter(function(data) {
+      return !filterNegative || data.tabIndex >= 0;
+    })
+    .sort(tabSort);
+};

--- a/dist/es2015/utils/tabUtils.d.ts
+++ b/dist/es2015/utils/tabUtils.d.ts
@@ -1,0 +1,2 @@
+export declare const getFocusables: (parents: HTMLElement[], withGuards?: boolean | undefined) => HTMLInputElement[];
+export declare const getParentAutofocusables: (parent: HTMLElement) => HTMLInputElement[];

--- a/dist/es2015/utils/tabUtils.js
+++ b/dist/es2015/utils/tabUtils.js
@@ -1,0 +1,27 @@
+import { FOCUS_AUTO } from '../constants';
+import { toArray } from './array';
+import { tabbables } from './tabbables';
+var queryTabbables = tabbables.join(',');
+var queryGuardTabbables = queryTabbables + ', [data-focus-guard]';
+export var getFocusables = function(parents, withGuards) {
+  return parents.reduce(function(acc, parent) {
+    return acc.concat(
+      toArray(parent.querySelectorAll(withGuards ? queryGuardTabbables : queryTabbables)),
+      parent.parentNode
+        ? toArray(parent.parentNode.querySelectorAll(queryTabbables)).filter(function(node) {
+            return node === parent;
+          })
+        : []
+    );
+  }, []);
+};
+export var getParentAutofocusables = function(parent) {
+  var parentFocus = parent.querySelectorAll('[' + FOCUS_AUTO + ']');
+  return toArray(parentFocus)
+    .map(function(node) {
+      return getFocusables([node]);
+    })
+    .reduce(function(acc, nodes) {
+      return acc.concat(nodes);
+    }, []);
+};

--- a/dist/es2015/utils/tabbables.d.ts
+++ b/dist/es2015/utils/tabbables.d.ts
@@ -1,0 +1,1 @@
+export declare const tabbables: string[];

--- a/dist/es2015/utils/tabbables.js
+++ b/dist/es2015/utils/tabbables.js
@@ -1,0 +1,17 @@
+export var tabbables = [
+  'button:enabled',
+  'select:enabled',
+  'textarea:enabled',
+  'input:enabled',
+  'a[href]',
+  'area[href]',
+  'summary',
+  'iframe',
+  'object',
+  'embed',
+  'audio[controls]',
+  'video[controls]',
+  '[tabindex]',
+  '[contenteditable]',
+  '[autofocus]',
+];

--- a/dist/es5/constants.d.ts
+++ b/dist/es5/constants.d.ts
@@ -1,0 +1,4 @@
+export declare const FOCUS_GROUP = 'data-focus-lock';
+export declare const FOCUS_DISABLED = 'data-focus-lock-disabled';
+export declare const FOCUS_ALLOW = 'data-no-focus-lock';
+export declare const FOCUS_AUTO = 'data-autofocus-inside';

--- a/dist/es5/constants.js
+++ b/dist/es5/constants.js
@@ -1,0 +1,7 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.FOCUS_AUTO = exports.FOCUS_ALLOW = exports.FOCUS_DISABLED = exports.FOCUS_GROUP = void 0;
+exports.FOCUS_GROUP = 'data-focus-lock';
+exports.FOCUS_DISABLED = 'data-focus-lock-disabled';
+exports.FOCUS_ALLOW = 'data-no-focus-lock';
+exports.FOCUS_AUTO = 'data-autofocus-inside';

--- a/dist/es5/focusInside.d.ts
+++ b/dist/es5/focusInside.d.ts
@@ -1,0 +1,1 @@
+export declare const focusInside: (topNode: HTMLElement | HTMLElement[]) => boolean;

--- a/dist/es5/focusInside.js
+++ b/dist/es5/focusInside.js
@@ -1,0 +1,24 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.focusInside = void 0;
+var all_affected_1 = require('./utils/all-affected');
+var array_1 = require('./utils/array');
+var focusInFrame = function(frame) {
+  return frame === document.activeElement;
+};
+var focusInsideIframe = function(topNode) {
+  return Boolean(
+    array_1.toArray(topNode.querySelectorAll('iframe')).some(function(node) {
+      return focusInFrame(node);
+    })
+  );
+};
+exports.focusInside = function(topNode) {
+  var activeElement = document && document.activeElement;
+  if (!activeElement || (activeElement.dataset && activeElement.dataset.focusGuard)) {
+    return false;
+  }
+  return all_affected_1.getAllAffectedNodes(topNode).reduce(function(result, node) {
+    return result || node.contains(activeElement) || focusInsideIframe(node);
+  }, false);
+};

--- a/dist/es5/focusIsHidden.d.ts
+++ b/dist/es5/focusIsHidden.d.ts
@@ -1,0 +1,1 @@
+export declare const focusIsHidden: () => boolean;

--- a/dist/es5/focusIsHidden.js
+++ b/dist/es5/focusIsHidden.js
@@ -1,0 +1,13 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.focusIsHidden = void 0;
+var constants_1 = require('./constants');
+var array_1 = require('./utils/array');
+exports.focusIsHidden = function() {
+  return (
+    document &&
+    array_1.toArray(document.querySelectorAll('[' + constants_1.FOCUS_ALLOW + ']')).some(function(node) {
+      return node.contains(document.activeElement);
+    })
+  );
+};

--- a/dist/es5/focusMerge.d.ts
+++ b/dist/es5/focusMerge.d.ts
@@ -1,0 +1,10 @@
+import { NodeIndex } from './utils/tabOrder';
+export declare const getFocusMerge: (
+  topNode: HTMLElement | HTMLElement[],
+  lastNode: HTMLInputElement | null
+) =>
+  | NodeIndex
+  | {
+      node: HTMLInputElement;
+    }
+  | undefined;

--- a/dist/es5/focusMerge.js
+++ b/dist/es5/focusMerge.js
@@ -1,0 +1,69 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.getFocusMerge = void 0;
+var solver_1 = require('./solver');
+var all_affected_1 = require('./utils/all-affected');
+var DOMutils_1 = require('./utils/DOMutils');
+var firstFocus_1 = require('./utils/firstFocus');
+var is_1 = require('./utils/is');
+var parenting_1 = require('./utils/parenting');
+var findAutoFocused = function(autoFocusables) {
+  return function(node) {
+    return node.autofocus || (node.dataset && !!node.dataset.autofocus) || autoFocusables.indexOf(node) >= 0;
+  };
+};
+var reorderNodes = function(srcNodes, dstNodes) {
+  var remap = new Map();
+  dstNodes.forEach(function(entity) {
+    return remap.set(entity.node, entity);
+  });
+  return srcNodes
+    .map(function(node) {
+      return remap.get(node);
+    })
+    .filter(is_1.isDefined);
+};
+exports.getFocusMerge = function(topNode, lastNode) {
+  var activeElement = document && document.activeElement;
+  var entries = all_affected_1.getAllAffectedNodes(topNode).filter(is_1.isNotAGuard);
+  var commonParent = parenting_1.getTopCommonParent(activeElement || topNode, topNode, entries);
+  var anyFocusable = DOMutils_1.getAllTabbableNodes(entries);
+  var innerElements = DOMutils_1.getTabbableNodes(entries).filter(function(_a) {
+    var node = _a.node;
+    return is_1.isNotAGuard(node);
+  });
+  if (!innerElements[0]) {
+    innerElements = anyFocusable;
+    if (!innerElements[0]) {
+      return undefined;
+    }
+  }
+  var outerNodes = DOMutils_1.getAllTabbableNodes([commonParent]).map(function(_a) {
+    var node = _a.node;
+    return node;
+  });
+  var orderedInnerElements = reorderNodes(outerNodes, innerElements);
+  var innerNodes = orderedInnerElements.map(function(_a) {
+    var node = _a.node;
+    return node;
+  });
+  var newId = solver_1.newFocus(innerNodes, outerNodes, activeElement, lastNode);
+  if (newId === solver_1.NEW_FOCUS) {
+    var autoFocusable = anyFocusable
+      .map(function(_a) {
+        var node = _a.node;
+        return node;
+      })
+      .filter(findAutoFocused(parenting_1.allParentAutofocusables(entries)));
+    return {
+      node:
+        autoFocusable && autoFocusable.length
+          ? firstFocus_1.pickFirstFocus(autoFocusable)
+          : firstFocus_1.pickFirstFocus(innerNodes),
+    };
+  }
+  if (newId === undefined) {
+    return newId;
+  }
+  return orderedInnerElements[newId];
+};

--- a/dist/es5/focusables.d.ts
+++ b/dist/es5/focusables.d.ts
@@ -1,0 +1,8 @@
+interface FocusableIn {
+  node: HTMLElement;
+  index: number;
+  lockItem: boolean;
+  guard: boolean;
+}
+export declare const getFocusabledIn: (topNode: HTMLElement) => FocusableIn[];
+export {};

--- a/dist/es5/focusables.js
+++ b/dist/es5/focusables.js
@@ -1,0 +1,31 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.getFocusabledIn = void 0;
+var all_affected_1 = require('./utils/all-affected');
+var DOMutils_1 = require('./utils/DOMutils');
+var is_1 = require('./utils/is');
+var parenting_1 = require('./utils/parenting');
+exports.getFocusabledIn = function(topNode) {
+  var entries = all_affected_1.getAllAffectedNodes(topNode).filter(is_1.isNotAGuard);
+  var commonParent = parenting_1.getTopCommonParent(topNode, topNode, entries);
+  var outerNodes = DOMutils_1.getTabbableNodes([commonParent], true);
+  var innerElements = DOMutils_1.getTabbableNodes(entries)
+    .filter(function(_a) {
+      var node = _a.node;
+      return is_1.isNotAGuard(node);
+    })
+    .map(function(_a) {
+      var node = _a.node;
+      return node;
+    });
+  return outerNodes.map(function(_a) {
+    var node = _a.node,
+      index = _a.index;
+    return {
+      node: node,
+      index: index,
+      lockItem: innerElements.indexOf(node) >= 0,
+      guard: is_1.isGuard(node),
+    };
+  });
+};

--- a/dist/es5/index.d.ts
+++ b/dist/es5/index.d.ts
@@ -1,0 +1,21 @@
+import * as constants from './constants';
+import { getFocusabledIn } from './focusables';
+import { focusInside } from './focusInside';
+import { focusIsHidden } from './focusIsHidden';
+import { getFocusMerge as focusMerge } from './focusMerge';
+import { setFocus } from './setFocus';
+import { focusNextElement, focusPrevElement } from './sibling';
+import tabHook from './tabHook';
+import { getAllAffectedNodes } from './utils/all-affected';
+export {
+  tabHook,
+  focusInside,
+  focusIsHidden,
+  focusMerge,
+  getFocusabledIn,
+  constants,
+  getAllAffectedNodes,
+  focusNextElement,
+  focusPrevElement,
+};
+export default setFocus;

--- a/dist/es5/index.js
+++ b/dist/es5/index.js
@@ -1,0 +1,58 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.focusPrevElement = exports.focusNextElement = exports.getAllAffectedNodes = exports.constants = exports.getFocusabledIn = exports.focusMerge = exports.focusIsHidden = exports.focusInside = exports.tabHook = void 0;
+var tslib_1 = require('tslib');
+var constants = tslib_1.__importStar(require('./constants'));
+exports.constants = constants;
+var focusables_1 = require('./focusables');
+Object.defineProperty(exports, 'getFocusabledIn', {
+  enumerable: true,
+  get: function() {
+    return focusables_1.getFocusabledIn;
+  },
+});
+var focusInside_1 = require('./focusInside');
+Object.defineProperty(exports, 'focusInside', {
+  enumerable: true,
+  get: function() {
+    return focusInside_1.focusInside;
+  },
+});
+var focusIsHidden_1 = require('./focusIsHidden');
+Object.defineProperty(exports, 'focusIsHidden', {
+  enumerable: true,
+  get: function() {
+    return focusIsHidden_1.focusIsHidden;
+  },
+});
+var focusMerge_1 = require('./focusMerge');
+Object.defineProperty(exports, 'focusMerge', {
+  enumerable: true,
+  get: function() {
+    return focusMerge_1.getFocusMerge;
+  },
+});
+var setFocus_1 = require('./setFocus');
+var sibling_1 = require('./sibling');
+Object.defineProperty(exports, 'focusNextElement', {
+  enumerable: true,
+  get: function() {
+    return sibling_1.focusNextElement;
+  },
+});
+Object.defineProperty(exports, 'focusPrevElement', {
+  enumerable: true,
+  get: function() {
+    return sibling_1.focusPrevElement;
+  },
+});
+var tabHook_1 = tslib_1.__importDefault(require('./tabHook'));
+exports.tabHook = tabHook_1.default;
+var all_affected_1 = require('./utils/all-affected');
+Object.defineProperty(exports, 'getAllAffectedNodes', {
+  enumerable: true,
+  get: function() {
+    return all_affected_1.getAllAffectedNodes;
+  },
+});
+exports.default = setFocus_1.setFocus;

--- a/dist/es5/setFocus.d.ts
+++ b/dist/es5/setFocus.d.ts
@@ -1,0 +1,2 @@
+export declare const focusOn: (target: HTMLInputElement | HTMLFrameElement) => void;
+export declare const setFocus: (topNode: HTMLElement, lastNode: HTMLInputElement) => void;

--- a/dist/es5/setFocus.js
+++ b/dist/es5/setFocus.js
@@ -1,0 +1,34 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.setFocus = exports.focusOn = void 0;
+var focusMerge_1 = require('./focusMerge');
+exports.focusOn = function(target) {
+  target.focus();
+  if ('contentWindow' in target && target.contentWindow) {
+    target.contentWindow.focus();
+  }
+};
+var guardCount = 0;
+var lockDisabled = false;
+exports.setFocus = function(topNode, lastNode) {
+  var focusable = focusMerge_1.getFocusMerge(topNode, lastNode);
+  if (lockDisabled) {
+    return;
+  }
+  if (focusable) {
+    if (guardCount > 2) {
+      console.error(
+        'FocusLock: focus-fighting detected. Only one focus management system could be active. ' +
+          'See https://github.com/theKashey/focus-lock/#focus-fighting'
+      );
+      lockDisabled = true;
+      setTimeout(function() {
+        lockDisabled = false;
+      }, 1);
+      return;
+    }
+    guardCount++;
+    exports.focusOn(focusable.node);
+    guardCount--;
+  }
+};

--- a/dist/es5/sibling.d.ts
+++ b/dist/es5/sibling.d.ts
@@ -1,0 +1,8 @@
+interface FocusNextOptions {
+  scope?: HTMLElement | HTMLDocument;
+  cycle?: boolean;
+  focusOptions?: FocusOptions;
+}
+export declare const focusNextElement: (baseElement: Element, options?: FocusNextOptions) => void;
+export declare const focusPrevElement: (baseElement: Element, options?: FocusNextOptions) => void;
+export {};

--- a/dist/es5/sibling.js
+++ b/dist/es5/sibling.js
@@ -1,0 +1,62 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.focusPrevElement = exports.focusNextElement = void 0;
+var DOMutils_1 = require('./utils/DOMutils');
+var getRelativeFocusable = function(element, scope) {
+  if (!element || !scope || !scope.contains(element)) {
+    return {};
+  }
+  var focusables = DOMutils_1.getTabbableNodes([scope]);
+  var current = focusables.findIndex(function(_a) {
+    var node = _a.node;
+    return node === element;
+  });
+  if (current === -1) {
+    return {};
+  }
+  return {
+    prev: focusables[current - 1],
+    next: focusables[current + 1],
+    first: focusables[0],
+    last: focusables[focusables.length - 1],
+  };
+};
+var defaultOptions = function(options) {
+  return Object.assign(
+    {
+      scope: document.body,
+      cycle: true,
+    },
+    options
+  );
+};
+exports.focusNextElement = function(baseElement, options) {
+  if (options === void 0) {
+    options = {};
+  }
+  var _a = defaultOptions(options),
+    scope = _a.scope,
+    cycle = _a.cycle;
+  var _b = getRelativeFocusable(baseElement, scope),
+    next = _b.next,
+    first = _b.first;
+  var newTarget = next || (cycle && first);
+  if (newTarget) {
+    newTarget.node.focus(options.focusOptions);
+  }
+};
+exports.focusPrevElement = function(baseElement, options) {
+  if (options === void 0) {
+    options = {};
+  }
+  var _a = defaultOptions(options),
+    scope = _a.scope,
+    cycle = _a.cycle;
+  var _b = getRelativeFocusable(baseElement, scope),
+    prev = _b.prev,
+    last = _b.last;
+  var newTarget = prev || (cycle && last);
+  if (newTarget) {
+    newTarget.node.focus(options.focusOptions);
+  }
+};

--- a/dist/es5/solver.d.ts
+++ b/dist/es5/solver.d.ts
@@ -1,0 +1,7 @@
+export declare const NEW_FOCUS = 'NEW_FOCUS';
+export declare const newFocus: (
+  innerNodes: HTMLInputElement[],
+  outerNodes: HTMLInputElement[],
+  activeElement: HTMLInputElement,
+  lastNode: HTMLInputElement | null
+) => number | undefined | typeof NEW_FOCUS;

--- a/dist/es5/solver.js
+++ b/dist/es5/solver.js
@@ -1,0 +1,55 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.newFocus = exports.NEW_FOCUS = void 0;
+var correctFocus_1 = require('./utils/correctFocus');
+var firstFocus_1 = require('./utils/firstFocus');
+var is_1 = require('./utils/is');
+exports.NEW_FOCUS = 'NEW_FOCUS';
+exports.newFocus = function(innerNodes, outerNodes, activeElement, lastNode) {
+  var cnt = innerNodes.length;
+  var firstFocus = innerNodes[0];
+  var lastFocus = innerNodes[cnt - 1];
+  var isOnGuard = is_1.isGuard(activeElement);
+  if (innerNodes.indexOf(activeElement) >= 0) {
+    return undefined;
+  }
+  var activeIndex = outerNodes.indexOf(activeElement);
+  var lastIndex = lastNode ? outerNodes.indexOf(lastNode) : activeIndex;
+  var lastNodeInside = lastNode ? innerNodes.indexOf(lastNode) : -1;
+  var indexDiff = activeIndex - lastIndex;
+  var firstNodeIndex = outerNodes.indexOf(firstFocus);
+  var lastNodeIndex = outerNodes.indexOf(lastFocus);
+  var correctedNodes = correctFocus_1.correctNodes(outerNodes);
+  var correctedIndexDiff =
+    correctedNodes.indexOf(activeElement) - (lastNode ? correctedNodes.indexOf(lastNode) : activeIndex);
+  var returnFirstNode = firstFocus_1.pickFocusable(innerNodes, 0);
+  var returnLastNode = firstFocus_1.pickFocusable(innerNodes, cnt - 1);
+  if (activeIndex === -1 || lastNodeInside === -1) {
+    return exports.NEW_FOCUS;
+  }
+  if (!indexDiff && lastNodeInside >= 0) {
+    return lastNodeInside;
+  }
+  if (activeIndex <= firstNodeIndex && isOnGuard && Math.abs(indexDiff) > 1) {
+    return returnLastNode;
+  }
+  if (activeIndex >= lastNodeIndex && isOnGuard && Math.abs(indexDiff) > 1) {
+    return returnFirstNode;
+  }
+  if (indexDiff && Math.abs(correctedIndexDiff) > 1) {
+    return lastNodeInside;
+  }
+  if (activeIndex <= firstNodeIndex) {
+    return returnLastNode;
+  }
+  if (activeIndex > lastNodeIndex) {
+    return returnFirstNode;
+  }
+  if (indexDiff) {
+    if (Math.abs(indexDiff) > 1) {
+      return lastNodeInside;
+    }
+    return (cnt + lastNodeInside + indexDiff) % cnt;
+  }
+  return undefined;
+};

--- a/dist/es5/tabHook.d.ts
+++ b/dist/es5/tabHook.d.ts
@@ -1,0 +1,5 @@
+declare const _default: {
+  attach(): void;
+  detach(): void;
+};
+export default _default;

--- a/dist/es5/tabHook.js
+++ b/dist/es5/tabHook.js
@@ -1,0 +1,6 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.default = {
+  attach: function() {},
+  detach: function() {},
+};

--- a/dist/es5/utils/DOMutils.d.ts
+++ b/dist/es5/utils/DOMutils.d.ts
@@ -1,0 +1,5 @@
+import { NodeIndex } from './tabOrder';
+export declare const filterFocusable: (nodes: HTMLInputElement[]) => HTMLInputElement[];
+export declare const getTabbableNodes: (topNodes: HTMLElement[], withGuards?: boolean | undefined) => NodeIndex[];
+export declare const getAllTabbableNodes: (topNodes: HTMLElement[]) => NodeIndex[];
+export declare const parentAutofocusables: (topNode: HTMLElement) => HTMLInputElement[];

--- a/dist/es5/utils/DOMutils.js
+++ b/dist/es5/utils/DOMutils.js
@@ -1,0 +1,30 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.parentAutofocusables = exports.getAllTabbableNodes = exports.getTabbableNodes = exports.filterFocusable = void 0;
+var array_1 = require('./array');
+var is_1 = require('./is');
+var tabOrder_1 = require('./tabOrder');
+var tabUtils_1 = require('./tabUtils');
+exports.filterFocusable = function(nodes) {
+  return array_1
+    .toArray(nodes)
+    .filter(function(node) {
+      return is_1.isVisible(node);
+    })
+    .filter(function(node) {
+      return is_1.notHiddenInput(node);
+    });
+};
+exports.getTabbableNodes = function(topNodes, withGuards) {
+  return tabOrder_1.orderByTabIndex(
+    exports.filterFocusable(tabUtils_1.getFocusables(topNodes, withGuards)),
+    true,
+    withGuards
+  );
+};
+exports.getAllTabbableNodes = function(topNodes) {
+  return tabOrder_1.orderByTabIndex(exports.filterFocusable(tabUtils_1.getFocusables(topNodes)), false);
+};
+exports.parentAutofocusables = function(topNode) {
+  return exports.filterFocusable(tabUtils_1.getParentAutofocusables(topNode));
+};

--- a/dist/es5/utils/all-affected.d.ts
+++ b/dist/es5/utils/all-affected.d.ts
@@ -1,0 +1,1 @@
+export declare const getAllAffectedNodes: (node: HTMLElement | HTMLElement[]) => HTMLInputElement[];

--- a/dist/es5/utils/all-affected.js
+++ b/dist/es5/utils/all-affected.js
@@ -1,0 +1,45 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.getAllAffectedNodes = void 0;
+var constants_1 = require('../constants');
+var array_1 = require('./array');
+var filterNested = function(nodes) {
+  var contained = new Set();
+  var l = nodes.length;
+  for (var i = 0; i < l; i += 1) {
+    for (var j = i + 1; j < l; j += 1) {
+      var position = nodes[i].compareDocumentPosition(nodes[j]);
+      if ((position & Node.DOCUMENT_POSITION_CONTAINED_BY) > 0) {
+        contained.add(j);
+      }
+      if ((position & Node.DOCUMENT_POSITION_CONTAINS) > 0) {
+        contained.add(i);
+      }
+    }
+  }
+  return nodes.filter(function(_, index) {
+    return !contained.has(index);
+  });
+};
+var getTopParent = function(node) {
+  return node.parentNode ? getTopParent(node.parentNode) : node;
+};
+exports.getAllAffectedNodes = function(node) {
+  var nodes = array_1.asArray(node);
+  return nodes.filter(Boolean).reduce(function(acc, currentNode) {
+    var group = currentNode.getAttribute(constants_1.FOCUS_GROUP);
+    acc.push.apply(
+      acc,
+      group
+        ? filterNested(
+            array_1.toArray(
+              getTopParent(currentNode).querySelectorAll(
+                '[' + constants_1.FOCUS_GROUP + '="' + group + '"]:not([' + constants_1.FOCUS_DISABLED + '="disabled"])'
+              )
+            )
+          )
+        : [currentNode]
+    );
+    return acc;
+  }, []);
+};

--- a/dist/es5/utils/array.d.ts
+++ b/dist/es5/utils/array.d.ts
@@ -1,0 +1,7 @@
+interface ListOf<TNode> {
+  length: number;
+  [index: number]: TNode;
+}
+export declare const toArray: <T>(a: ListOf<T> | T[]) => T[];
+export declare const asArray: <T>(a: T | T[]) => T[];
+export {};

--- a/dist/es5/utils/array.js
+++ b/dist/es5/utils/array.js
@@ -1,0 +1,13 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.asArray = exports.toArray = void 0;
+exports.toArray = function(a) {
+  var ret = Array(a.length);
+  for (var i = 0; i < a.length; ++i) {
+    ret[i] = a[i];
+  }
+  return ret;
+};
+exports.asArray = function(a) {
+  return Array.isArray(a) ? a : [a];
+};

--- a/dist/es5/utils/correctFocus.d.ts
+++ b/dist/es5/utils/correctFocus.d.ts
@@ -1,0 +1,2 @@
+export declare const correctNode: (node: HTMLInputElement, nodes: HTMLInputElement[]) => HTMLInputElement;
+export declare const correctNodes: (nodes: HTMLInputElement[]) => HTMLInputElement[];

--- a/dist/es5/utils/correctFocus.js
+++ b/dist/es5/utils/correctFocus.js
@@ -1,0 +1,33 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.correctNodes = exports.correctNode = void 0;
+var isRadio = function(node) {
+  return node.tagName === 'INPUT' && node.type === 'radio';
+};
+var findSelectedRadio = function(node, nodes) {
+  return (
+    nodes
+      .filter(isRadio)
+      .filter(function(el) {
+        return el.name === node.name;
+      })
+      .filter(function(el) {
+        return el.checked;
+      })[0] || node
+  );
+};
+exports.correctNode = function(node, nodes) {
+  if (isRadio(node) && node.name) {
+    return findSelectedRadio(node, nodes);
+  }
+  return node;
+};
+exports.correctNodes = function(nodes) {
+  var resultSet = new Set();
+  nodes.forEach(function(node) {
+    return resultSet.add(exports.correctNode(node, nodes));
+  });
+  return nodes.filter(function(node) {
+    return resultSet.has(node);
+  });
+};

--- a/dist/es5/utils/firstFocus.d.ts
+++ b/dist/es5/utils/firstFocus.d.ts
@@ -1,0 +1,2 @@
+export declare const pickFirstFocus: (nodes: HTMLInputElement[]) => HTMLInputElement;
+export declare const pickFocusable: (nodes: HTMLInputElement[], index: number) => number;

--- a/dist/es5/utils/firstFocus.js
+++ b/dist/es5/utils/firstFocus.js
@@ -1,0 +1,16 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.pickFocusable = exports.pickFirstFocus = void 0;
+var correctFocus_1 = require('./correctFocus');
+exports.pickFirstFocus = function(nodes) {
+  if (nodes[0] && nodes.length > 1) {
+    return correctFocus_1.correctNode(nodes[0], nodes);
+  }
+  return nodes[0];
+};
+exports.pickFocusable = function(nodes, index) {
+  if (nodes.length > 1) {
+    return nodes.indexOf(correctFocus_1.correctNode(nodes[index], nodes));
+  }
+  return index;
+};

--- a/dist/es5/utils/is.d.ts
+++ b/dist/es5/utils/is.d.ts
@@ -1,0 +1,5 @@
+export declare const isVisible: (node: HTMLElement | undefined) => boolean;
+export declare const notHiddenInput: (node: HTMLInputElement) => boolean;
+export declare const isGuard: (node: HTMLElement) => boolean;
+export declare const isNotAGuard: (node: HTMLElement) => boolean;
+export declare const isDefined: <T>(x: T | null | undefined) => x is T;

--- a/dist/es5/utils/is.js
+++ b/dist/es5/utils/is.js
@@ -1,0 +1,36 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.isDefined = exports.isNotAGuard = exports.isGuard = exports.notHiddenInput = exports.isVisible = void 0;
+var isElementHidden = function(computedStyle) {
+  if (!computedStyle || !computedStyle.getPropertyValue) {
+    return false;
+  }
+  return (
+    computedStyle.getPropertyValue('display') === 'none' || computedStyle.getPropertyValue('visibility') === 'hidden'
+  );
+};
+exports.isVisible = function(node) {
+  return (
+    !node ||
+    node === document ||
+    (node && node.nodeType === Node.DOCUMENT_NODE) ||
+    (!isElementHidden(window.getComputedStyle(node, null)) &&
+      exports.isVisible(
+        node.parentNode && node.parentNode.nodeType === Node.DOCUMENT_FRAGMENT_NODE
+          ? node.parentNode.host
+          : node.parentNode
+      ))
+  );
+};
+exports.notHiddenInput = function(node) {
+  return !((node.tagName === 'INPUT' || node.tagName === 'BUTTON') && (node.type === 'hidden' || node.disabled));
+};
+exports.isGuard = function(node) {
+  return Boolean(node && node.dataset && node.dataset.focusGuard);
+};
+exports.isNotAGuard = function(node) {
+  return !exports.isGuard(node);
+};
+exports.isDefined = function(x) {
+  return Boolean(x);
+};

--- a/dist/es5/utils/parenting.d.ts
+++ b/dist/es5/utils/parenting.d.ts
@@ -1,0 +1,7 @@
+export declare const getCommonParent: (nodeA: HTMLElement, nodeB: HTMLElement) => false | HTMLElement;
+export declare const getTopCommonParent: (
+  baseActiveElement: HTMLElement,
+  leftEntry: HTMLElement | HTMLElement[],
+  rightEntries: HTMLElement[]
+) => HTMLElement;
+export declare const allParentAutofocusables: (entries: HTMLElement[]) => HTMLInputElement[];

--- a/dist/es5/utils/parenting.js
+++ b/dist/es5/utils/parenting.js
@@ -1,0 +1,51 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.allParentAutofocusables = exports.getTopCommonParent = exports.getCommonParent = void 0;
+var array_1 = require('./array');
+var DOMutils_1 = require('./DOMutils');
+var getParents = function(node, parents) {
+  if (parents === void 0) {
+    parents = [];
+  }
+  parents.push(node);
+  if (node.parentNode) {
+    getParents(node.parentNode, parents);
+  }
+  return parents;
+};
+exports.getCommonParent = function(nodeA, nodeB) {
+  var parentsA = getParents(nodeA);
+  var parentsB = getParents(nodeB);
+  for (var i = 0; i < parentsA.length; i += 1) {
+    var currentParent = parentsA[i];
+    if (parentsB.indexOf(currentParent) >= 0) {
+      return currentParent;
+    }
+  }
+  return false;
+};
+exports.getTopCommonParent = function(baseActiveElement, leftEntry, rightEntries) {
+  var activeElements = array_1.asArray(baseActiveElement);
+  var leftEntries = array_1.asArray(leftEntry);
+  var activeElement = activeElements[0];
+  var topCommon = false;
+  leftEntries.filter(Boolean).forEach(function(entry) {
+    topCommon = exports.getCommonParent(topCommon || entry, entry) || topCommon;
+    rightEntries.filter(Boolean).forEach(function(subEntry) {
+      var common = exports.getCommonParent(activeElement, subEntry);
+      if (common) {
+        if (!topCommon || common.contains(topCommon)) {
+          topCommon = common;
+        } else {
+          topCommon = exports.getCommonParent(common, topCommon);
+        }
+      }
+    });
+  });
+  return topCommon;
+};
+exports.allParentAutofocusables = function(entries) {
+  return entries.reduce(function(acc, node) {
+    return acc.concat(DOMutils_1.parentAutofocusables(node));
+  }, []);
+};

--- a/dist/es5/utils/tabOrder.d.ts
+++ b/dist/es5/utils/tabOrder.d.ts
@@ -1,0 +1,11 @@
+export interface NodeIndex {
+  node: HTMLInputElement;
+  tabIndex: number;
+  index: number;
+}
+export declare const tabSort: (a: NodeIndex, b: NodeIndex) => number;
+export declare const orderByTabIndex: (
+  nodes: HTMLInputElement[],
+  filterNegative: boolean,
+  keepGuards?: boolean | undefined
+) => NodeIndex[];

--- a/dist/es5/utils/tabOrder.js
+++ b/dist/es5/utils/tabOrder.js
@@ -1,0 +1,32 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.orderByTabIndex = exports.tabSort = void 0;
+var array_1 = require('./array');
+exports.tabSort = function(a, b) {
+  var tabDiff = a.tabIndex - b.tabIndex;
+  var indexDiff = a.index - b.index;
+  if (tabDiff) {
+    if (!a.tabIndex) {
+      return 1;
+    }
+    if (!b.tabIndex) {
+      return -1;
+    }
+  }
+  return tabDiff || indexDiff;
+};
+exports.orderByTabIndex = function(nodes, filterNegative, keepGuards) {
+  return array_1
+    .toArray(nodes)
+    .map(function(node, index) {
+      return {
+        node: node,
+        index: index,
+        tabIndex: keepGuards && node.tabIndex === -1 ? ((node.dataset || {}).focusGuard ? 0 : -1) : node.tabIndex,
+      };
+    })
+    .filter(function(data) {
+      return !filterNegative || data.tabIndex >= 0;
+    })
+    .sort(exports.tabSort);
+};

--- a/dist/es5/utils/tabUtils.d.ts
+++ b/dist/es5/utils/tabUtils.d.ts
@@ -1,0 +1,2 @@
+export declare const getFocusables: (parents: HTMLElement[], withGuards?: boolean | undefined) => HTMLInputElement[];
+export declare const getParentAutofocusables: (parent: HTMLElement) => HTMLInputElement[];

--- a/dist/es5/utils/tabUtils.js
+++ b/dist/es5/utils/tabUtils.js
@@ -1,0 +1,31 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.getParentAutofocusables = exports.getFocusables = void 0;
+var constants_1 = require('../constants');
+var array_1 = require('./array');
+var tabbables_1 = require('./tabbables');
+var queryTabbables = tabbables_1.tabbables.join(',');
+var queryGuardTabbables = queryTabbables + ', [data-focus-guard]';
+exports.getFocusables = function(parents, withGuards) {
+  return parents.reduce(function(acc, parent) {
+    return acc.concat(
+      array_1.toArray(parent.querySelectorAll(withGuards ? queryGuardTabbables : queryTabbables)),
+      parent.parentNode
+        ? array_1.toArray(parent.parentNode.querySelectorAll(queryTabbables)).filter(function(node) {
+            return node === parent;
+          })
+        : []
+    );
+  }, []);
+};
+exports.getParentAutofocusables = function(parent) {
+  var parentFocus = parent.querySelectorAll('[' + constants_1.FOCUS_AUTO + ']');
+  return array_1
+    .toArray(parentFocus)
+    .map(function(node) {
+      return exports.getFocusables([node]);
+    })
+    .reduce(function(acc, nodes) {
+      return acc.concat(nodes);
+    }, []);
+};

--- a/dist/es5/utils/tabbables.d.ts
+++ b/dist/es5/utils/tabbables.d.ts
@@ -1,0 +1,1 @@
+export declare const tabbables: string[];

--- a/dist/es5/utils/tabbables.js
+++ b/dist/es5/utils/tabbables.js
@@ -1,0 +1,20 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.tabbables = void 0;
+exports.tabbables = [
+  'button:enabled',
+  'select:enabled',
+  'textarea:enabled',
+  'input:enabled',
+  'a[href]',
+  'area[href]',
+  'summary',
+  'iframe',
+  'object',
+  'embed',
+  'audio[controls]',
+  'video[controls]',
+  '[tabindex]',
+  '[contenteditable]',
+  '[autofocus]',
+];

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kulevw/focus-lock",
+  "name": "kulevw-focus-lock",
   "version": "0.8.2",
   "description": "DOM trap for a focus",
   "main": "dist/es5/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kulevw-focus-lock",
+  "name": "@kulevw/focus-lock",
   "version": "0.8.2",
   "description": "DOM trap for a focus",
   "main": "dist/es5/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "focus-lock",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "DOM trap for a focus",
   "main": "dist/es5/index.js",
   "jsnext:main": "dist/es2015/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "focus-lock",
+  "name": "kulevw/focus-lock",
   "version": "0.8.2",
   "description": "DOM trap for a focus",
   "main": "dist/es5/index.js",

--- a/src/sibling.ts
+++ b/src/sibling.ts
@@ -29,6 +29,10 @@ interface FocusNextOptions {
    * @default true
    */
   cycle?: boolean;
+  /**
+   * options for focus call
+   */
+  focusOptions?: FocusOptions;
 }
 
 const defaultOptions = (options: FocusNextOptions) =>
@@ -50,7 +54,7 @@ export const focusNextElement = (baseElement: Element, options: FocusNextOptions
   const { next, first } = getRelativeFocusable(baseElement as HTMLInputElement, scope);
   const newTarget = next || (cycle && first);
   if (newTarget) {
-    newTarget.node.focus();
+    newTarget.node.focus(options.focusOptions);
   }
 };
 
@@ -64,6 +68,6 @@ export const focusPrevElement = (baseElement: Element, options: FocusNextOptions
   const { prev, last } = getRelativeFocusable(baseElement as HTMLInputElement, scope);
   const newTarget = prev || (cycle && last);
   if (newTarget) {
-    newTarget.node.focus();
+    newTarget.node.focus(options.focusOptions);
   }
 };


### PR DESCRIPTION
I use focus-lock for focus management in modal dialogs, but focus-lock have helpers functions for focus management and I use sibling functions for custom select input