### PR TITLE
cache visibility check results for reuse within a single operation

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -1,6 +1,6 @@
 [
   {
     path: "dist/es2015/index.js",
-    limit: "2.3 KB"
+    limit: "2.35 KB"
   }
 ]

--- a/.size.json
+++ b/.size.json
@@ -2,6 +2,6 @@
   {
     "name": "dist/es2015/index.js",
     "passed": true,
-    "size": 2346
+    "size": 2393
   }
 ]

--- a/__tests__/footprint.spec.ts
+++ b/__tests__/footprint.spec.ts
@@ -28,13 +28,13 @@ describe('Complexity footprint', () => {
   it('known operation complexity - no focus', () => {
     createTest();
     focusMerge(querySelector('#d1'), null);
-    expect(window.getComputedStyle).toBeCalledTimes(32);
+    expect(window.getComputedStyle).toBeCalledTimes(16);
   });
 
   it('known operation complexity - has focus inside', () => {
     createTest();
     querySelector('#b1').focus();
     focusMerge(querySelector('#d1'), null);
-    expect(window.getComputedStyle).toBeCalledTimes(24);
+    expect(window.getComputedStyle).toBeCalledTimes(8);
   });
 });

--- a/src/focusMerge.ts
+++ b/src/focusMerge.ts
@@ -22,9 +22,10 @@ export const getFocusMerge = (topNode: HTMLElement | HTMLElement[], lastNode: HT
   const entries = getAllAffectedNodes(topNode).filter(isNotAGuard);
 
   const commonParent = getTopCommonParent(activeElement || topNode, topNode, entries);
+  const visibilityCache = new Map();
 
-  const anyFocusable = getAllTabbableNodes(entries);
-  let innerElements = getTabbableNodes(entries).filter(({ node }) => isNotAGuard(node));
+  const anyFocusable = getAllTabbableNodes(entries, visibilityCache);
+  let innerElements = getTabbableNodes(entries, visibilityCache).filter(({ node }) => isNotAGuard(node));
 
   if (!innerElements[0]) {
     innerElements = anyFocusable;
@@ -33,7 +34,7 @@ export const getFocusMerge = (topNode: HTMLElement | HTMLElement[], lastNode: HT
     }
   }
 
-  const outerNodes = getAllTabbableNodes([commonParent]).map(({ node }) => node);
+  const outerNodes = getAllTabbableNodes([commonParent], visibilityCache).map(({ node }) => node);
   const orderedInnerElements = reorderNodes(outerNodes, innerElements);
   const innerNodes = orderedInnerElements.map(({ node }) => node);
 
@@ -42,7 +43,7 @@ export const getFocusMerge = (topNode: HTMLElement | HTMLElement[], lastNode: HT
   if (newId === NEW_FOCUS) {
     const autoFocusable = anyFocusable
       .map(({ node }) => node)
-      .filter(findAutoFocused(allParentAutofocusables(entries)));
+      .filter(findAutoFocused(allParentAutofocusables(entries, visibilityCache)));
 
     return {
       node: autoFocusable && autoFocusable.length ? pickFirstFocus(autoFocusable) : pickFirstFocus(innerNodes),

--- a/src/focusables.ts
+++ b/src/focusables.ts
@@ -13,8 +13,9 @@ interface FocusableIn {
 export const getFocusabledIn = (topNode: HTMLElement) => {
   const entries = getAllAffectedNodes(topNode).filter(isNotAGuard);
   const commonParent = getTopCommonParent(topNode, topNode, entries);
-  const outerNodes = getTabbableNodes([commonParent], true);
-  const innerElements = getTabbableNodes(entries)
+  const visibilityCache = new Map();
+  const outerNodes = getTabbableNodes([commonParent], visibilityCache, true);
+  const innerElements = getTabbableNodes(entries, visibilityCache)
     .filter(({ node }) => isNotAGuard(node))
     .map(({ node }) => node);
 

--- a/src/sibling.ts
+++ b/src/sibling.ts
@@ -4,7 +4,7 @@ const getRelativeFocusable = (element: HTMLInputElement, scope: HTMLElement | HT
   if (!element || !scope || !scope.contains(element)) {
     return {};
   }
-  const focusables = getTabbableNodes([scope as HTMLElement]);
+  const focusables = getTabbableNodes([scope as HTMLElement], new Map());
   const current = focusables.findIndex(({ node }) => node === element);
   if (current === -1) {
     return {};

--- a/src/utils/DOMutils.ts
+++ b/src/utils/DOMutils.ts
@@ -1,26 +1,26 @@
 import { toArray } from './array';
-import { isVisible, notHiddenInput } from './is';
+import { isVisibleCached, notHiddenInput, VisibilityCache } from './is';
 import { NodeIndex, orderByTabIndex } from './tabOrder';
 import { getFocusables, getParentAutofocusables } from './tabUtils';
 
-export const filterFocusable = (nodes: HTMLInputElement[]): HTMLInputElement[] =>
+export const filterFocusable = (nodes: HTMLInputElement[], visibilityCache: VisibilityCache): HTMLInputElement[] =>
   toArray(nodes)
-    .filter((node) => isVisible(node))
+    .filter((node) => isVisibleCached(node, visibilityCache))
     .filter((node) => notHiddenInput(node));
 
 /**
  * only tabbable ones
  * (but with guards which would be ignored)
  */
-export const getTabbableNodes = (topNodes: HTMLElement[], withGuards?: boolean): NodeIndex[] =>
-  orderByTabIndex(filterFocusable(getFocusables(topNodes, withGuards)), true, withGuards);
+export const getTabbableNodes = (topNodes: HTMLElement[], visibilityCache: VisibilityCache, withGuards?: boolean): NodeIndex[] =>
+  orderByTabIndex(filterFocusable(getFocusables(topNodes, withGuards), visibilityCache), true, withGuards);
 
 /**
  * actually anything "focusable", not only tabbable
  * (without guards, as long as they are not expected to be focused)
  */
-export const getAllTabbableNodes = (topNodes: HTMLElement[]) =>
-  orderByTabIndex(filterFocusable(getFocusables(topNodes)), false);
+export const getAllTabbableNodes = (topNodes: HTMLElement[], visibilityCache: VisibilityCache) =>
+  orderByTabIndex(filterFocusable(getFocusables(topNodes), visibilityCache), false);
 
-export const parentAutofocusables = (topNode: HTMLElement): HTMLInputElement[] =>
-  filterFocusable(getParentAutofocusables(topNode));
+export const parentAutofocusables = (topNode: HTMLElement, visibilityCache: VisibilityCache): HTMLInputElement[] =>
+  filterFocusable(getParentAutofocusables(topNode), visibilityCache);

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -7,7 +7,7 @@ const isElementHidden = (computedStyle: CSSStyleDeclaration): boolean => {
   );
 };
 
-export const isVisible = (node: HTMLElement | undefined): boolean =>
+const isVisible = (node: HTMLElement | undefined): boolean =>
   !node ||
   // @ts-ignore
   node === document ||
@@ -18,6 +18,18 @@ export const isVisible = (node: HTMLElement | undefined): boolean =>
         ? (node.parentNode as any).host
         : node.parentNode
     ));
+
+export type VisibilityCache = Map<HTMLElement | undefined, boolean>;
+
+export const isVisibleCached = (node: HTMLElement | undefined, visibilityCache: VisibilityCache): boolean => {
+  const cached = visibilityCache.get(node)
+  if (cached !== undefined) {
+    return cached;
+  }
+  const result = isVisible(node);
+  visibilityCache.set(node, result)
+  return result;
+};
 
 export const notHiddenInput = (node: HTMLInputElement) =>
   !((node.tagName === 'INPUT' || node.tagName === 'BUTTON') && (node.type === 'hidden' || node.disabled));

--- a/src/utils/parenting.ts
+++ b/src/utils/parenting.ts
@@ -1,5 +1,6 @@
 import { asArray } from './array';
 import { parentAutofocusables } from './DOMutils';
+import { VisibilityCache } from "./is";
 
 const getParents = (node: HTMLElement, parents: HTMLElement[] = []): HTMLElement[] => {
   parents.push(node);
@@ -55,5 +56,5 @@ export const getTopCommonParent = (
   // TODO: add assert here?
   return (topCommon as unknown) as HTMLInputElement;
 };
-export const allParentAutofocusables = (entries: HTMLElement[]): HTMLInputElement[] =>
-  entries.reduce((acc, node) => acc.concat(parentAutofocusables(node)), [] as HTMLInputElement[]);
+export const allParentAutofocusables = (entries: HTMLElement[], visibilityCache: VisibilityCache): HTMLInputElement[] =>
+  entries.reduce((acc, node) => acc.concat(parentAutofocusables(node, visibilityCache)), [] as HTMLInputElement[]);


### PR DESCRIPTION
My naive attempt to fix: theKashey/react-focus-lock#151

I confirmed this in my real application case, it prevents Jest test from getting timed out.
