### PR TITLE
Query shadow dom focusables

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -1,6 +1,6 @@
 [
   {
     path: "dist/es2015/index.js",
-    limit: "2.58 kB"
+    limit: "2.591 kB"
   }
 ]

--- a/.size-limit
+++ b/.size-limit
@@ -1,6 +1,6 @@
 [
   {
     path: "dist/es2015/index.js",
-    limit: "2.5 kB"
+    limit: "2.58 kB"
   }
 ]

--- a/.size.json
+++ b/.size.json
@@ -2,6 +2,6 @@
   {
     "name": "dist/es2015/index.js",
     "passed": true,
-    "size": 2558
+    "size": 2641
   }
 ]

--- a/.size.json
+++ b/.size.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "dist/es2015/index.js",
-    "passed": true,
-    "size": 2641
+    "passed": false,
+    "size": 2653
   }
 ]

--- a/__tests__/focusIsHidden.spec.ts
+++ b/__tests__/focusIsHidden.spec.ts
@@ -1,0 +1,114 @@
+import { focusIsHidden, constants } from '../src';
+
+describe('focusIsHidden', () => {
+  const setupTest = () => {
+    document.body.innerHTML = `
+      <div ${constants.FOCUS_ALLOW}>
+        <button id="focus-hidden"></button>
+      </div>
+      <button id="focus-not-hidden"></button>
+    `;
+  };
+
+  it('returns true when the focused element is hidden', () => {
+    setupTest();
+
+    const button = document.querySelector('#focus-hidden') as HTMLButtonElement;
+
+    button.focus();
+
+    expect(focusIsHidden()).toBe(true);
+  });
+
+  it('returns false when the focused element is not hidden', () => {
+    setupTest();
+
+    const button = document.querySelector('#focus-not-hidden') as HTMLButtonElement;
+
+    button.focus();
+
+    expect(focusIsHidden()).toBe(false);
+  });
+
+  const setupShadowTest = (nested?: boolean) => {
+    const html = `
+      <div id="app">
+        <div id="nonshadow">
+          <input />
+          <button>I am a button</button>
+        </div>
+        <div id="shadowdom"></div>
+      </div>`;
+    const shadowHtml = `
+      <div id="first"></div>
+      <button id="firstBtn">first button</button>
+      <div id="last">
+        <button id="secondBtn">second button</button>
+      </div>
+      `;
+    document.body.innerHTML = html;
+
+    const shadowContainer = document.getElementById('shadowdom') as HTMLElement;
+    const root = shadowContainer.attachShadow({ mode: 'open' });
+    const shadowDiv = document.createElement('div');
+    shadowDiv.innerHTML = shadowHtml;
+    root.appendChild(shadowDiv);
+
+    if (nested) {
+      const firstDiv = root.querySelector('#first') as HTMLDivElement;
+      const nestedRoot = firstDiv.attachShadow({ mode: 'open' });
+      const nestedShadowDiv = document.createElement('div');
+
+      nestedShadowDiv.innerHTML = shadowHtml;
+      nestedRoot.appendChild(nestedShadowDiv);
+    }
+  };
+
+  it('looks for focus within shadow doms', () => {
+    setupShadowTest();
+
+    const shadowHost = document.querySelector('#shadowdom') as HTMLDivElement;
+    const button = shadowHost.shadowRoot?.querySelector('#firstBtn') as HTMLButtonElement;
+
+    button.focus();
+
+    expect(focusIsHidden()).toBe(false);
+
+    shadowHost.setAttribute(constants.FOCUS_ALLOW, '');
+
+    expect(focusIsHidden()).toBe(true);
+  });
+
+  it('looks for focus within nested shadow doms', () => {
+    setupShadowTest(true);
+
+    const shadowHost = document.querySelector('#shadowdom') as HTMLDivElement;
+    const nestedShadowHost = shadowHost.shadowRoot?.querySelector('#first') as HTMLDivElement;
+    const button = nestedShadowHost.shadowRoot?.querySelector('#firstBtn') as HTMLButtonElement;
+
+    button.focus();
+
+    expect(focusIsHidden()).toBe(false);
+
+    shadowHost.setAttribute(constants.FOCUS_ALLOW, '');
+
+    expect(focusIsHidden()).toBe(true);
+  });
+
+  it('does not support marking shadow members as FOCUS_ALLOW', () => {
+    setupShadowTest();
+
+    const shadowHost = document.querySelector('#shadowdom') as HTMLDivElement;
+    const shadowDiv = shadowHost.shadowRoot?.querySelector('#last') as HTMLDivElement;
+    const button = shadowDiv.children[0] as HTMLButtonElement;
+
+    button.focus();
+
+    expect(focusIsHidden()).toBe(false);
+
+    // Setting elements within shadow doms as FOCUS_ALLOW not supported
+    shadowDiv.setAttribute(constants.FOCUS_ALLOW, '');
+
+    expect(focusIsHidden()).toBe(false);
+  });
+});

--- a/__tests__/shadow-dom.spec.ts
+++ b/__tests__/shadow-dom.spec.ts
@@ -74,8 +74,8 @@ describe('shadow dow ', () => {
     `;
   });
 
-  it('web components respect tabIndex', () => {
-    expect.assertions(1);
+  it.only('web components respect tabIndex', () => {
+    expect.assertions(2);
 
     class FocusOutsideShadow extends HTMLElement {
       public connectedCallback() {
@@ -88,8 +88,15 @@ describe('shadow dow ', () => {
         const shadow = this.attachShadow({ mode: 'open' });
         shadow.innerHTML = html;
 
+        const input = shadow.querySelector('input') as HTMLInputElement;
+        const button = shadow.querySelector('button') as HTMLButtonElement;
+
         expect(focusMerge(document.body, null)).toEqual({
           node: document.querySelector('#focused'),
+        });
+
+        expect(focusMerge([input, button], null)).toEqual({
+          node: input,
         });
       }
     }

--- a/__tests__/shadow-dom.spec.ts
+++ b/__tests__/shadow-dom.spec.ts
@@ -1,11 +1,13 @@
-import { focusMerge } from '../src';
+import { focusMerge, focusNextElement, focusPrevElement } from '../src';
 
 describe('shadow dow ', () => {
   afterEach(() => {
     document.getElementsByTagName('html')[0].innerHTML = '';
   });
+
   it('supports detached elements', () => {
     document.body.innerHTML = `<div><button></button></div>`;
+
     const frag = document.createDocumentFragment();
     const button = document.createElement('button');
     frag.appendChild(button);
@@ -29,23 +31,25 @@ describe('shadow dow ', () => {
           <div id="last"></div>
       `;
     document.body.innerHTML = html;
+
     const shadowContainer = document.getElementById('shadowdom') as HTMLElement;
     const root = shadowContainer.attachShadow({ mode: 'open' });
     const shadowDiv = document.createElement('div');
     shadowDiv.innerHTML = shadowHtml;
     root.appendChild(shadowDiv);
+
     const firstBtn = root.getElementById('firstBtn');
+
     expect(focusMerge(shadowDiv, null)).toEqual({
       node: firstBtn,
     });
   });
 
-  // customElements are not supported
-  it.skip('web components dom element', () => {
+  it('web components dom element', () => {
     // source: https://github.com/pearofducks/focus-lock-reproduction
     expect.assertions(1);
 
-    class ReproElement extends HTMLElement {
+    class FocusWithinShadow extends HTMLElement {
       public connectedCallback() {
         const html = `
           <div id="app">
@@ -55,17 +59,138 @@ describe('shadow dow ', () => {
         `;
         const shadow = this.attachShadow({ mode: 'open' });
         shadow.innerHTML = html;
-        const app = shadow.querySelector('#app');
-        expect(focusMerge(app! as any, null)).toEqual({
-          node: expect.anything(),
+
+        expect(focusMerge(document.body, null)).toEqual({
+          node: shadow.querySelector('input'),
         });
       }
     }
 
-    if (!customElements.get('repro-element')) {
-      customElements.define('repro-element', ReproElement);
+    customElements.define('focus-within-shadow', FocusWithinShadow);
+
+    document.body.innerHTML = `
+      <focus-within-shadow></focus-within-shadow>
+      <button>I should not be focused<button>
+    `;
+  });
+
+  it('web components respect tabIndex', () => {
+    expect.assertions(1);
+
+    class FocusOutsideShadow extends HTMLElement {
+      public connectedCallback() {
+        const html = `
+          <div id="app">
+            <input />
+            <button>I am a button</button>
+          </div>
+        `;
+        const shadow = this.attachShadow({ mode: 'open' });
+        shadow.innerHTML = html;
+
+        expect(focusMerge(document.body, null)).toEqual({
+          node: document.querySelector('#focused'),
+        });
+      }
     }
 
-    document.body.innerHTML = `<repro-element></repro-element>`;
+    customElements.define('focus-outside-shadow', FocusOutsideShadow);
+
+    document.body.innerHTML = `
+      <focus-outside-shadow></focus-outside-shadow>
+      <button id="focused" tabindex="100" >I should be focused<button>
+    `;
+  });
+
+  it('focusNextElement w/ web components respects out of order tabIndex', () => {
+    expect.assertions(4);
+
+    class FocusNextOOO extends HTMLElement {
+      public connectedCallback() {
+        const html = `
+          <div id="app">
+            <input />
+            <button tabindex="3"></button>
+          </div>
+        `;
+        const shadow = this.attachShadow({ mode: 'open' });
+        shadow.innerHTML = html;
+
+        const shadowInput = shadow.querySelector('input') as HTMLInputElement;
+        const shadowButton = shadow.querySelector('button') as HTMLButtonElement;
+        const input = document.querySelector('input') as HTMLInputElement;
+        const button = document.querySelector('button') as HTMLButtonElement;
+
+        focusMerge(document.body, null)?.node?.focus();
+
+        expect(document.activeElement).toBe(input);
+
+        focusNextElement(input);
+
+        expect(document.activeElement).toBe(button);
+
+        focusNextElement(button);
+
+        expect(document.activeElement?.shadowRoot?.activeElement).toBe(shadowButton);
+
+        focusNextElement(shadowButton);
+
+        expect(document.activeElement?.shadowRoot?.activeElement).toBe(shadowInput);
+      }
+    }
+
+    customElements.define('focus-next-ooo', FocusNextOOO);
+
+    document.body.innerHTML = `
+      <input tabIndex="1"></button>
+      <focus-next-ooo></focus-next-ooo>
+      <button tabindex="2"></button>
+    `;
+  });
+
+  it('focusPrevElement w/ web components respects out of order tabIndex', () => {
+    expect.assertions(4);
+
+    class FocusPrevOOO extends HTMLElement {
+      public connectedCallback() {
+        const html = `
+          <div id="app">
+            <input />
+            <button tabindex="3"></button>
+          </div>
+        `;
+        const shadow = this.attachShadow({ mode: 'open' });
+        shadow.innerHTML = html;
+
+        const shadowInput = shadow.querySelector('input') as HTMLInputElement;
+        const shadowButton = shadow.querySelector('button') as HTMLButtonElement;
+        const input = document.querySelector('input') as HTMLInputElement;
+        const button = document.querySelector('button') as HTMLButtonElement;
+
+        focusMerge(document.body, null)?.node?.focus();
+
+        expect(document.activeElement).toBe(input);
+
+        focusPrevElement(input);
+
+        expect(document.activeElement?.shadowRoot?.activeElement).toBe(shadowInput);
+
+        focusPrevElement(shadowInput);
+
+        expect(document.activeElement?.shadowRoot?.activeElement).toBe(shadowButton);
+
+        focusPrevElement(shadowButton);
+
+        expect(document.activeElement).toBe(button);
+      }
+    }
+
+    customElements.define('focus-prev-ooo', FocusPrevOOO);
+
+    document.body.innerHTML = `
+      <input tabIndex="1"></button>
+      <focus-prev-ooo></focus-prev-ooo>
+      <button tabindex="2"></button>
+    `;
   });
 });

--- a/__tests__/shadow-dom.spec.ts
+++ b/__tests__/shadow-dom.spec.ts
@@ -74,7 +74,7 @@ describe('shadow dow ', () => {
     `;
   });
 
-  it.only('web components respect tabIndex', () => {
+  it('web components respect tabIndex', () => {
     expect.assertions(2);
 
     class FocusOutsideShadow extends HTMLElement {

--- a/src/focusInside.ts
+++ b/src/focusInside.ts
@@ -1,3 +1,4 @@
+import { contains } from './utils/DOMutils';
 import { getAllAffectedNodes } from './utils/all-affected';
 import { toArray } from './utils/array';
 import { getActiveElement } from './utils/getActiveElement';
@@ -14,8 +15,5 @@ export const focusInside = (topNode: HTMLElement | HTMLElement[]): boolean => {
     return false;
   }
 
-  return getAllAffectedNodes(topNode).reduce(
-    (result, node) => result || node.contains(activeElement) || focusInsideIframe(node),
-    false as boolean
-  );
+  return getAllAffectedNodes(topNode).some((node) => contains(node, activeElement) || focusInsideIframe(node));
 };

--- a/src/focusIsHidden.ts
+++ b/src/focusIsHidden.ts
@@ -1,4 +1,5 @@
 import { FOCUS_ALLOW } from './constants';
+import { contains } from './utils/DOMutils';
 import { toArray } from './utils/array';
 import { getActiveElement } from './utils/getActiveElement';
 
@@ -14,5 +15,6 @@ export const focusIsHidden = (): boolean => {
     return false;
   }
 
-  return toArray(document.querySelectorAll(`[${FOCUS_ALLOW}]`)).some((node) => node.contains(activeElement));
+  // this does not support setting FOCUS_ALLOW within shadow dom
+  return toArray(document.querySelectorAll(`[${FOCUS_ALLOW}]`)).some((node) => contains(node, activeElement));
 };

--- a/src/sibling.ts
+++ b/src/sibling.ts
@@ -1,8 +1,18 @@
 import { focusOn } from './setFocus';
 import { getTabbableNodes } from './utils/DOMutils';
 
+// need to search within shadowRoots (and potentially nested shadowRoots) for
+// the element
+const contains = (scope: Element, element: Element): boolean => {
+  return (
+    scope.contains(element) ||
+    (scope as HTMLElement).shadowRoot?.contains(element) ||
+    Array.from(scope.children).some((child) => contains(child, element))
+  );
+};
+
 const getRelativeFocusable = (element: Element, scope: HTMLElement | HTMLDocument) => {
-  if (!element || !scope || !scope.contains(element)) {
+  if (!element || !scope || !contains(scope as Element, element)) {
     return {};
   }
 

--- a/src/sibling.ts
+++ b/src/sibling.ts
@@ -1,15 +1,5 @@
 import { focusOn } from './setFocus';
-import { getTabbableNodes } from './utils/DOMutils';
-
-// need to search within shadowRoots (and potentially nested shadowRoots) for
-// the element
-const contains = (scope: Element, element: Element): boolean => {
-  return (
-    scope.contains(element) ||
-    (scope as HTMLElement).shadowRoot?.contains(element) ||
-    Array.from(scope.children).some((child) => contains(child, element))
-  );
-};
+import { getTabbableNodes, contains } from './utils/DOMutils';
 
 const getRelativeFocusable = (element: Element, scope: HTMLElement | HTMLDocument) => {
   if (!element || !scope || !contains(scope as Element, element)) {

--- a/src/utils/DOMutils.ts
+++ b/src/utils/DOMutils.ts
@@ -28,3 +28,14 @@ export const getAllTabbableNodes = (topNodes: Element[], visibilityCache: Visibi
 
 export const parentAutofocusables = (topNode: Element, visibilityCache: VisibilityCache): Element[] =>
   filterFocusable(getParentAutofocusables(topNode), visibilityCache);
+
+/*
+ * Determines if element is contained in scope, including nested shadow DOMs
+ */
+export const contains = (scope: Element | ShadowRoot, element: Element): boolean => {
+  return (
+    ((scope as HTMLElement).shadowRoot
+      ? contains((scope as HTMLElement).shadowRoot as ShadowRoot, element)
+      : scope.contains(element)) || Array.from(scope.children).some((child) => contains(child, element))
+  );
+};

--- a/src/utils/getActiveElement.ts
+++ b/src/utils/getActiveElement.ts
@@ -1,13 +1,19 @@
+const getNestedShadowActiveElement = (shadowRoot: ShadowRoot): HTMLElement | undefined =>
+  shadowRoot.activeElement
+    ? shadowRoot.activeElement.shadowRoot
+      ? getNestedShadowActiveElement(shadowRoot.activeElement.shadowRoot)
+      : (shadowRoot.activeElement as HTMLElement)
+    : undefined;
+
 /**
- * returns active element from document or from shadowdom
+ * returns active element from document or from nested shadowdoms
  */
 export const getActiveElement = (): HTMLElement | undefined => {
   return (
     document.activeElement
       ? document.activeElement.shadowRoot
-        ? document.activeElement.shadowRoot.activeElement
+        ? getNestedShadowActiveElement(document.activeElement.shadowRoot)
         : document.activeElement
       : undefined
-  ) as // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  any;
+  ) as any; // eslint-disable-next-line @typescript-eslint/no-explicit-any
 };

--- a/src/utils/parenting.ts
+++ b/src/utils/parenting.ts
@@ -1,4 +1,5 @@
 import { parentAutofocusables } from './DOMutils';
+import { contains } from './DOMutils';
 import { asArray } from './array';
 import { VisibilityCache } from './is';
 
@@ -6,7 +7,7 @@ const getParents = (node: Element, parents: Element[] = []): Element[] => {
   parents.push(node);
 
   if (node.parentNode) {
-    getParents(node.parentNode as HTMLElement, parents);
+    getParents((node.parentNode as ShadowRoot).host || node.parentNode, parents);
   }
 
   return parents;
@@ -51,7 +52,7 @@ export const getTopCommonParent = (
       const common = getCommonParent(activeElement, subEntry);
 
       if (common) {
-        if (!topCommon || common.contains(topCommon)) {
+        if (!topCommon || contains(common, topCommon)) {
           topCommon = common;
         } else {
           topCommon = getCommonParent(common, topCommon);

--- a/src/utils/tabUtils.ts
+++ b/src/utils/tabUtils.ts
@@ -5,13 +5,23 @@ import { tabbables } from './tabbables';
 const queryTabbables = tabbables.join(',');
 const queryGuardTabbables = `${queryTabbables}, [data-focus-guard]`;
 
+const getFocusablesWithShadowDom = (parent: Element, withGuards?: boolean): HTMLElement[] =>
+  toArray(parent.shadowRoot?.children || parent.children).reduce(
+    (acc, child) =>
+      acc.concat(
+        child.matches(withGuards ? queryGuardTabbables : queryTabbables) ? [child as HTMLElement] : [],
+        getFocusablesWithShadowDom(child)
+      ),
+    [] as HTMLElement[]
+  );
+
 export const getFocusables = (parents: Element[], withGuards?: boolean): HTMLElement[] =>
   parents.reduce(
     (acc, parent) =>
       acc.concat(
-        // add all tabbables inside
-        toArray(parent.querySelectorAll(withGuards ? queryGuardTabbables : queryTabbables)),
-        // add if node is tabbale itself
+        // add all tabbables inside and within shadow DOMs in DOM order
+        getFocusablesWithShadowDom(parent, withGuards),
+        // add if node is tabbable itself
         parent.parentNode
           ? toArray(parent.parentNode.querySelectorAll<HTMLElement>(queryTabbables)).filter((node) => node === parent)
           : []


### PR DESCRIPTION
This PR aims to further improve support for focusable elements within shadow doms and nested shadow doms. 

This primary changes are:
- Searches shadow DOMs and nested shadow DOMs in `getFocusables`, previously this method would not search within shadow doms for focusable elements. This modification adds the shadow focusable elements in DOM order (depth first). This allows `focusNextElement` and `focusPrevElement` to appropriately pass focus to shadow DOMs or custom elements within a focus lock.
- Adds `contains` to DOMUtils, used to determine whether an element is contained within another, including any nested shadow DOMs, this allows `focusInside` and `focusIsHidden` to correctly report when the focused element is within a shadow DOM. Previously, `getActiveElement` was added to get the active element from within a Shadow DOM, but the shadow dom was not being traversed when looking for that element (because `Node.contains()` does not check shadow doms).

It should be noted that this does add or fix support for marking shadow dom elements with any of the `data-` attributes found in the constants, used to control the behavior of the focus lock. This is outside of our use case for the focus lock, our team uses `react-focus-lock` (in preact), but consumes web components from our organizations design system that we need to be able to focus when within a focus lock.

This should fix https://github.com/theKashey/react-focus-lock/issues/206