### PR TITLE
Replace Array.from with built-in helper

### DIFF
--- a/src/utils/DOMutils.ts
+++ b/src/utils/DOMutils.ts
@@ -49,6 +49,6 @@ export const contains = (scope: Element | ShadowRoot, element: Element): boolean
   return (
     ((scope as HTMLElement).shadowRoot
       ? contains((scope as HTMLElement).shadowRoot as ShadowRoot, element)
-      : scope.contains(element)) || Array.from(scope.children).some((child) => contains(child, element))
+      : scope.contains(element)) || toArray(scope.children).some((child) => contains(child, element))
   );
 };


### PR DESCRIPTION
Hello!

The latest release 0.11.0 introduced dependency on `Array.from`. Unfortunately, we still do not have this available in all our environments ¯\_(ツ)_/¯ 

Fortunately, this is easily fixable, because you already have a util in place