### PR TITLE
fix: Skip `.contains` if it is not available

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -1,6 +1,6 @@
 [
   {
     path: "dist/es2015/index.js",
-    limit: "2.7 kB"
+    limit: "2.76 kB"
   }
 ]

--- a/.size.json
+++ b/.size.json
@@ -2,6 +2,6 @@
   {
     "name": "dist/es2015/index.js",
     "passed": true,
-    "size": 2757
+    "size": 2765
   }
 ]

--- a/src/utils/DOMutils.ts
+++ b/src/utils/DOMutils.ts
@@ -46,10 +46,16 @@ export const parentAutofocusables = (topNode: Element, visibilityCache: Visibili
  * Determines if element is contained in scope, including nested shadow DOMs
  */
 export const contains = (scope: Element | ShadowRoot, element: Element): boolean => {
-  return (
-    ((scope as HTMLElement).shadowRoot
-      ? contains((scope as HTMLElement).shadowRoot as ShadowRoot, element)
-      : Object.getPrototypeOf(scope).contains.call(scope, element)) ||
-    toArray(scope.children).some((child) => contains(child, element))
-  );
+  if ((scope as HTMLElement).shadowRoot) {
+    return contains((scope as HTMLElement).shadowRoot as ShadowRoot, element);
+  } else {
+    if (
+      Object.getPrototypeOf(scope).contains !== undefined &&
+      Object.getPrototypeOf(scope).contains.call(scope, element)
+    ) {
+      return true;
+    }
+
+    return toArray(scope.children).some((child) => contains(child, element));
+  }
 };


### PR DESCRIPTION
Some browsers (e.g. IE) do not provide the `.contains` function on some nodes, for example SVGElements. The call to `.contains` throws an error then.

After this change, the call to `.contains` is skipped if the element does not have that function.