### PR TITLE
fix: missing node in setFocus

### DIFF
--- a/src/setFocus.ts
+++ b/src/setFocus.ts
@@ -34,7 +34,7 @@ export const setFocus = (topNode: HTMLElement, lastNode: Element, options: Focus
     return;
   }
 
-  if (focusable) {
+  if (focusable && focusable.node) {
     if (guardCount > 2) {
       // tslint:disable-next-line:no-console
       console.error(


### PR DESCRIPTION
For some reasons the node could be undefined which throws an error. This PR should fix that bug