### PR TITLE
Query IFrames focusables

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -1,6 +1,6 @@
 [
   {
     path: "dist/es2015/index.js",
-    limit: "2.76 kB"
+    limit: "2.88 kB"
   }
 ]

--- a/.size.json
+++ b/.size.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "dist/es2015/index.js",
-    "passed": true,
-    "size": 2792
+    "passed": false,
+    "size": 2969
   }
 ]

--- a/.size.json
+++ b/.size.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "dist/es2015/index.js",
-    "passed": false,
-    "size": 2969
+    "passed": true,
+    "size": 2947
   }
 ]

--- a/__tests__/focusIsHidden.spec.ts
+++ b/__tests__/focusIsHidden.spec.ts
@@ -115,4 +115,111 @@ describe('focusIsHidden', () => {
       runTest(shadowDiv, button, false, false);
     });
   });
+
+  describe('iframes', () => {
+    const setupIFrame = () => {
+      const html = `
+      <div id="app">
+        <div id="noniframe">
+          <input />
+          <button>I am a button</button>
+        </div>
+        <div id="iframe-container">
+          <iframe></iframe>
+        </div>
+      </div>`;
+      const iframeHtml = `
+      <div id="first"></div>
+      <button id="firstBtn">first button</button>
+      <div id="last">
+        <button id="secondBtn">second button</button>
+      </div>
+      `;
+
+      document.body.innerHTML = html;
+
+      const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+      const root = iframe.contentDocument;
+
+      if (!root) {
+        throw new Error('Unable to get iframe content document');
+      }
+
+      root.write(iframeHtml);
+
+      return { root, iframeHtml };
+    };
+
+    const setupNestedIFrame = () => {
+      const { root, iframeHtml } = setupIFrame();
+
+      const firstDiv = root.querySelector('#first') as HTMLDivElement;
+      const nestedIFrame = document.createElement('iframe');
+      firstDiv.append(nestedIFrame);
+
+      const nestedIFrameRoot = nestedIFrame.contentDocument;
+
+      if (!nestedIFrameRoot) {
+        throw new Error('Unable to get iframe content document');
+      }
+
+      nestedIFrameRoot.write(iframeHtml);
+
+      return { root, iframeHtml };
+    };
+
+    const runTest = (
+      iframeContainer: HTMLDivElement,
+      button: HTMLButtonElement,
+      shouldBeHidden: boolean,
+      shouldBeDiscovered: boolean
+    ) => {
+      button.focus();
+      expect(focusIsHidden()).toBe(shouldBeHidden);
+
+      iframeContainer.setAttribute(constants.FOCUS_ALLOW, '');
+
+      expect(focusIsHidden()).toBe(shouldBeDiscovered);
+    };
+
+    describe('FOCUS_ALLOW behavior', () => {
+      it('looks for focus within iframes', () => {
+        const { root } = setupIFrame();
+
+        const iframeContainer = document.querySelector('#iframe-container') as HTMLDivElement;
+        const button = root.querySelector('#firstBtn') as HTMLButtonElement;
+
+        runTest(iframeContainer, button, false, true);
+      });
+
+      it('looks for focus within nested iframes', () => {
+        const { root } = setupNestedIFrame();
+
+        const iframeContainer = document.querySelector('#iframe-container') as HTMLDivElement;
+        const nestedIframe = root.querySelector('iframe') as HTMLIFrameElement;
+
+        const nestedIFrameRoot = nestedIframe.contentDocument;
+
+        if (!nestedIFrameRoot) {
+          throw new Error('Unable to get iframe content document');
+        }
+
+        // JSDom doesn't properly support focusing directly in a nested iframe.
+        // As a workaround we need to first focus in the iframe and then on the button
+        nestedIframe.focus();
+
+        const button = nestedIFrameRoot.querySelector('#firstBtn') as HTMLButtonElement;
+        runTest(iframeContainer, button, false, true);
+      });
+    });
+
+    it('does not support marking shadow members as FOCUS_ALLOW', () => {
+      const { root } = setupIFrame();
+
+      const iframeDiv = root.querySelector('#last') as HTMLDivElement;
+      const button = iframeDiv.children[0] as HTMLButtonElement;
+
+      runTest(iframeDiv, button, false, false);
+    });
+  });
 });

--- a/__tests__/iframe.spec.ts
+++ b/__tests__/iframe.spec.ts
@@ -1,0 +1,142 @@
+import { focusMerge, focusNextElement /*, focusPrevElement*/ } from '../src';
+
+describe('iframes', () => {
+  afterEach(() => {
+    document.getElementsByTagName('html')[0].innerHTML = '';
+  });
+
+  it('support for iframes', () => {
+    const html = `
+      <div id="app">
+            <input />
+            <button>I am a button</button>
+          <iframe></iframe>
+      </div>`;
+    const iframeHtml = `
+          <div id="first"></div>
+          <button id="firstBtn">first button</button>
+          <button id="secondBtn">second button</button>
+          <div id="last"></div>
+      `;
+    document.body.innerHTML = html;
+
+    const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+    const root = iframe.contentDocument;
+
+    if (!root) {
+      throw new Error('Unable to get iframe content document');
+    }
+
+    root.write(iframeHtml);
+
+    const firstBtn = root.getElementById('firstBtn');
+
+    expect(focusMerge(root.body, null)).toEqual({
+      node: firstBtn,
+    });
+  });
+
+  it('iframe dom element', () => {
+    const html = `
+      <div id="app">
+            <input />
+            <button>I am a button</button>
+          <iframe></iframe>
+          <button>I should be not be focused<button>
+      </div>`;
+    const iframeHtml = `
+      <input />
+      <button>I am a button</button>
+      `;
+    document.body.innerHTML = html;
+
+    const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+    const root = iframe.contentDocument;
+
+    if (!root) {
+      throw new Error('Unable to get iframe content document');
+    }
+
+    root.write(iframeHtml);
+
+    const input = root.querySelector('input') as HTMLInputElement;
+
+    expect(focusMerge(document.body, null)).toEqual({
+      node: input,
+    });
+  });
+
+  it('iframe respect tabIndex', () => {
+    const html = `
+      <div id="app">
+            <input />
+            <button>I am a button</button>
+          <iframe></iframe>
+          <button id="focused" tabindex="100" >I should be focused<button>
+      </div>`;
+    const iframeHtml = `
+    <input />
+    <button>I am a button</button>
+      `;
+    document.body.innerHTML = html;
+
+    const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+    const root = iframe.contentDocument;
+
+    if (!root) {
+      throw new Error('Unable to get iframe content document');
+    }
+
+    root.write(iframeHtml);
+
+    const input = root.querySelector('input') as HTMLInputElement;
+    const button = root.querySelector('button') as HTMLButtonElement;
+
+    expect(focusMerge(document.body, null)).toEqual({
+      node: document.querySelector('#focused'),
+    });
+
+    expect(focusMerge([input, button], null)).toEqual({
+      node: input,
+    });
+  });
+
+  it('focusNextElement w/in iframes respects out of order tabIndex', () => {
+    document.body.innerHTML = `
+      <input tabIndex="1"></button>
+      <iframe></iframe>
+      <button tabindex="2"></button>
+    `;
+
+    const iframeHtml = `
+      <div id="app">
+        <input />
+        <button tabindex="3"></button>
+      </div>
+    `;
+
+    const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+    const root = iframe.contentDocument;
+
+    if (!root) {
+      throw new Error('Unable to get iframe content document');
+    }
+
+    root.write(iframeHtml);
+
+    const iframeInput = root.querySelector('input') as HTMLInputElement;
+    const iframeButton = root.querySelector('button') as HTMLButtonElement;
+    const input = document.querySelector('input') as HTMLInputElement;
+    const button = document.querySelector('button') as HTMLButtonElement;
+
+    focusMerge(document.body, null)?.node?.focus();
+    expect(document.activeElement).toBe(input);
+
+    focusNextElement(input);
+    expect(document.activeElement).toBe(button);
+    focusNextElement(button);
+    expect(root.activeElement).toBe(iframeButton);
+    focusNextElement(iframeButton);
+    expect(root.activeElement).toBe(iframeInput);
+  });
+});

--- a/src/focusInside.ts
+++ b/src/focusInside.ts
@@ -18,5 +18,7 @@ export const focusInside = (topNode: HTMLElement | HTMLElement[]): boolean => {
     return false;
   }
 
-  return getAllAffectedNodes(topNode).some((node) => contains(node, activeElement) || focusInsideIframe(node));
+  return getAllAffectedNodes(topNode).some((node) => {
+    return contains(node, activeElement) || focusInsideIframe(node);
+  });
 };

--- a/src/utils/DOMutils.ts
+++ b/src/utils/DOMutils.ts
@@ -56,6 +56,18 @@ export const contains = (scope: Element | ShadowRoot, element: Element): boolean
       return true;
     }
 
-    return toArray(scope.children).some((child) => contains(child, element));
+    return toArray(scope.children).some((child) => {
+      if (child instanceof HTMLIFrameElement) {
+        const iframeBody = (child as HTMLIFrameElement).contentDocument?.body;
+
+        if (iframeBody) {
+          return contains(iframeBody, element);
+        }
+
+        return false;
+      }
+
+      return contains(child, element);
+    });
   }
 };

--- a/src/utils/getActiveElement.ts
+++ b/src/utils/getActiveElement.ts
@@ -5,6 +5,16 @@ const getNestedShadowActiveElement = (shadowRoot: ShadowRoot): HTMLElement | und
       : (shadowRoot.activeElement as HTMLElement)
     : undefined;
 
+const getNestedIframeActiveElement = (iframe: HTMLIFrameElement): HTMLElement | undefined => {
+  const activeElement = iframe?.contentWindow?.document?.activeElement;
+
+  return activeElement
+    ? activeElement instanceof HTMLIFrameElement
+      ? getNestedIframeActiveElement(activeElement)
+      : (activeElement as HTMLElement)
+    : undefined;
+};
+
 /**
  * returns active element from document or from nested shadowdoms
  */
@@ -13,6 +23,8 @@ export const getActiveElement = (): HTMLElement | undefined => {
     document.activeElement
       ? document.activeElement.shadowRoot
         ? getNestedShadowActiveElement(document.activeElement.shadowRoot)
+        : document.activeElement instanceof HTMLIFrameElement
+        ? getNestedIframeActiveElement(document.activeElement)
         : document.activeElement
       : undefined
   ) as any; // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Currently `focus-lock` doesn't work as expected when the content of an iframe is dynamically updated. 
For example if content of the iframe is added using `ReactDOM.createPortal` the focus is stuck on the first focusable element: https://codesandbox.io/s/focus-lock-issue-with-dynamic-iframes-hfujkh?file=/src/App.tsx (Click on "Open in iframe" and then try tabbing to a different input. The focus is stuck on "enter your name")

 This PR handle iframes the same way it does with shadow nodes and has been heavily inspired by https://github.com/theKashey/focus-lock/pull/33. It checks if the active element is an iframe and if it's the case look for tabbable element in the iframe document to prevent the focus to get stuck on the iframe element itself.

