### PR TITLE
fix: correct tabIndex calculation for exotic components, fixes #55

### DIFF
--- a/__tests__/focusMerge.spec.ts
+++ b/__tests__/focusMerge.spec.ts
@@ -58,6 +58,19 @@ describe('FocusMerge', () => {
     expect(focusSolver(querySelector('#d1'), null)!.node.innerHTML).toBe('2');
   });
 
+  it('autofocus - should pick first available exotic tabbable', () => {
+    document.body.innerHTML = `    
+        <div id="d1"> 
+        <span>
+            <div contenteditable="true">1</div>
+        </span>
+        <button>2</button>
+        </div>    
+    `;
+
+    expect(focusSolver(querySelector('#d1'), null)!.node.innerHTML).toBe('1');
+  });
+
   it('autofocus - should pick first available tabbable | first ignored', () => {
     document.body.innerHTML = `    
         <div id="d1"> 

--- a/src/utils/tabOrder.ts
+++ b/src/utils/tabOrder.ts
@@ -23,14 +23,29 @@ export const tabSort = (a: NodeIndex, b: NodeIndex): number => {
   return tabDiff || indexDiff;
 };
 
+const getTabIndex = (node: HTMLElement): number => {
+  if (node.tabIndex < 0) {
+    // all "focusable" elements are already preselected
+    // but some might have implicit negative tabIndex
+    // return 0 for <audio without tabIndex attribute - it is "tabbable"
+    if (!node.hasAttribute('tabindex')) {
+      return 0;
+    }
+  }
+
+  return node.tabIndex;
+};
+
 export const orderByTabIndex = (nodes: HTMLElement[], filterNegative: boolean, keepGuards?: boolean): NodeIndex[] =>
   toArray(nodes)
-    .map(
-      (node, index): NodeIndex => ({
+    .map((node, index): NodeIndex => {
+      const tabIndex = getTabIndex(node);
+
+      return {
         node,
         index,
-        tabIndex: keepGuards && node.tabIndex === -1 ? ((node.dataset || {}).focusGuard ? 0 : -1) : node.tabIndex,
-      })
-    )
+        tabIndex: keepGuards && tabIndex === -1 ? ((node.dataset || {}).focusGuard ? 0 : -1) : tabIndex,
+      };
+    })
     .filter((data) => !filterNegative || data.tabIndex >= 0)
     .sort(tabSort);


### PR DESCRIPTION
Not audio/video/contentEditable and other elements with implicit tabIndex=-1 will be considered as tabbables.