### PR TITLE
feat: implement return focus

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -1,6 +1,6 @@
 [
   {
     path: "dist/es2015/index.js",
-    limit: "3.1 kB"
+    limit: "3.5 kB"
   }
 ]

--- a/.size.json
+++ b/.size.json
@@ -2,6 +2,6 @@
   {
     "name": "dist/es2015/index.js",
     "passed": true,
-    "size": 3132
+    "size": 3491
   }
 ]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,26 @@ if (someNode && !focusInside(someNode)) {
 }
 ```
 
+> note that tracking `lastActiveFocus` is on the end user.
+
+## Declarative control
+
+`focus-lock` provides not only API to be called by some other scripts, but also a way one can leave instructions inside HTML markup
+to amend focus behavior in a desired way.
+
+These are `data-attributes` one can add on the elements:
+
+- control
+  - `data-focus-lock=[group-name]` to create a focus group (scattered focus)
+  - `data-focus-lock-disabled="disabled"` marks such group as disabled and removes from the list. Equal to removing elements from the DOM.
+  - `data-no-focus-lock` focus-lock will ignore/allow focus inside marked area. Focus on this elements will not be managed by focus-lock.
+- autofocus (via `moveFocusInside(someNode, null)`)
+  - `data-autofocus` will autofocus marked element on activation.
+  - `data-autofocus-inside` focus-lock will try to autofocus elements within selected area on activation.
+  - `data-no-autofocus` focus-lock will not autofocus any node within marked area on activation.
+
+These markers are available as `import * as markers from 'focus-lock/constants'`
+
 ## Additional API
 
 ### Get focusable nodes
@@ -37,23 +57,36 @@ Returns visible and focusable nodes
 ```ts
 import { expandFocusableNodes, getFocusableNodes, getTabbleNodes } from 'focus-lock';
 
-// returns an "extended information" but focusable nodes inside. To be used for advances cases (react-focus-lock)
-expandFocusableNodes(singleNodes);
-
 // returns all focusable nodes inside given locations
 getFocusableNodes([many, nodes])[0].node.focus();
 
 // returns all nodes reacheable in the "taborder" inside given locations
 getTabbleNodes([many, nodes])[0].node.focus();
+
+// returns an "extended information" about focusable nodes inside. To be used for advances cases (react-focus-lock)
+expandFocusableNodes(singleNodes);
 ```
 
 ### Programmatic focus management
 
+Allows moving back and forth between focusable/tabbable elements
+
 ```ts
 import { focusNextElement, focusPrevElement } from 'focus-lock';
-focusNextElement(sourceElement, {
+focusNextElement(document.activeElement, {
   scope: theBoundingDOMNode,
 }); // -> next tabbable element
+```
+
+### Return focus
+
+Advanced API to return focus (from the Modal) to the last or the next best location
+
+```ts
+import { captureFocusRestore } from 'focus-lock';
+const restore = captureFocusRestore(element);
+// ....
+restore()?.focus(); // restores focus the the element, or it's siblings in case it no longer exists
 ```
 
 # WHY?
@@ -66,24 +99,6 @@ From [MDN Article about accessible dialogs](https://developer.mozilla.org/en-US/
 This one is about managing the focus.
 
 I'v got a good [article about focus management, dialogs and WAI-ARIA](https://medium.com/@antonkorzunov/its-a-focus-trap-699a04d66fb5).
-
-# Declarative control
-
-`Focus-lock` provides not only API to be called by some other scripts, but also a way one can leave instructions inside HTML markup
-to amend focus behavior in a desired way.
-
-These are data-attributes one can add on the elements:
-
-- control
-  - `data-focus-lock` to create a focus group (scattered focus)
-  - `data-focus-lock-disabled` marks such group as disabled and removes from the list
-  - `data-no-focus-lock` focus-lock will ignore focus inside marked area
-- autofocus
-  - `data-autofocus` will autofocus marked element on activation. Require _control delegation_ to focus-lock
-  - `data-autofocus-inside` focus-lock will try to autofocus elements within selected area
-  - `data-no-autofocus` focus-lock will not autofocus any node within marked area
-
-These markers are available as `import * as markers from 'focus-lock/constants'`
 
 # Focus fighting
 

--- a/__tests__/return-focus.spec.ts
+++ b/__tests__/return-focus.spec.ts
@@ -1,0 +1,97 @@
+import { captureFocusRestore } from '../src/return-focus';
+
+const getb = () => {
+  const b1 = document.getElementById('b1')! as HTMLButtonElement;
+  const restore = captureFocusRestore(b1);
+
+  return { b1, restore };
+};
+
+test('returns focus to the original location', () => {
+  document.body.innerHTML = `
+     <div><button id="b1"></button></div>
+   `;
+
+  const { b1, restore } = getb();
+  expect(restore()).toBe(b1);
+});
+
+test('on deletion returns focus to the element to the right location', () => {
+  document.body.innerHTML = `
+     <div><button id="b0"><button id="b1"><button id="b3"></button></div>
+   `;
+
+  const { b1, restore } = getb();
+  b1.parentElement!.removeChild(b1);
+  expect(restore()).toBe(document.getElementById('b3'));
+});
+
+test('on deletion returns focus to the element to the right location with spaces', () => {
+  document.body.innerHTML = `
+     <div><button id="b0"><button id="b1"><span/><button id="b3"></button></div>
+   `;
+
+  const { b1, restore } = getb();
+  b1.parentElement!.removeChild(b1);
+  expect(restore()).toBe(document.getElementById('b3'));
+});
+
+test('on deletion returns focus to the focusable element', () => {
+  document.body.innerHTML = `
+     <div><button id="b0"><button id="b1"><span/><button disabled id="b3"></button></div>
+   `;
+
+  const { b1, restore } = getb();
+  b1.parentElement!.removeChild(b1);
+  expect(restore()).toBe(document.getElementById('b0'));
+});
+
+test('moves focus when default element becomes non focusable', () => {
+  document.body.innerHTML = `
+     <div><button id="b1"><button id="b3"></button></div>
+   `;
+
+  const { b1, restore } = getb();
+  b1.disabled = true;
+  expect(restore()).toBe(document.getElementById('b3'));
+});
+
+test('on deletion returns where possible to the left', () => {
+  document.body.innerHTML = `
+     <div><button id="b0"><button id="b1"></button></div><button id="b3">
+   `;
+
+  const { b1, restore } = getb();
+  b1.parentElement!.removeChild(b1);
+  expect(restore()).toBe(document.getElementById('b0'));
+});
+
+test('picks some focusable at the same level', () => {
+  document.body.innerHTML = `
+     <div><button id="b0"><span/><span/><button id="b1"></button><span/></div><button id="b3">
+   `;
+
+  const { b1, restore } = getb();
+  b1.parentElement!.removeChild(b1);
+  expect(restore()).toBe(document.getElementById('b0'));
+});
+
+test('moves parents to find focusable', () => {
+  document.body.innerHTML = `
+     <div><button id="b1"></button></div><button id="b3">
+   `;
+
+  const { b1, restore } = getb();
+  b1.parentElement!.removeChild(b1);
+  expect(restore()).toBe(document.getElementById('b3'));
+});
+
+test('returns undefined if nothing focusable', () => {
+  document.body.innerHTML = `
+     <div><button id="b1"></button></div>
+   `;
+
+  const { b1, restore } = getb();
+  b1.parentElement!.removeChild(b1);
+  expect(restore()).toBe(undefined);
+});

--- a/src/focusables.ts
+++ b/src/focusables.ts
@@ -20,10 +20,12 @@ interface FocusableNode {
 }
 
 /**
- * @returns list of focusable elements inside a given top node
- * @see {@link getFocusableNodes} for lower level access
+ * traverses all related nodes (including groups) returning a list of all nodes(outer and internal) with meta information
+ * This is low-level API!
+ * @returns list of focusable elements inside a given top(!) node.
+ * @see {@link getFocusableNodes} providing a simpler API
  */
-export const expandFocusableNodes = (topNode: HTMLElement): FocusableNode[] => {
+export const expandFocusableNodes = (topNode: HTMLElement | HTMLElement[]): FocusableNode[] => {
   const entries = getAllAffectedNodes(topNode).filter(isNotAGuard);
   const commonParent = getTopCommonParent(topNode, topNode, entries);
   const visibilityCache = new Map();

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export {
   focusNextElement,
   focusPrevElement,
   getRelativeFocusable,
+  //
   captureFocusRestore,
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { focusIsHidden } from './focusIsHidden';
 import { focusSolver } from './focusSolver';
 import { expandFocusableNodes } from './focusables';
 import { moveFocusInside } from './moveFocusInside';
+import { captureFocusRestore } from './return-focus';
 import { focusNextElement, focusPrevElement, getRelativeFocusable } from './sibling';
 import { getFocusableNodes, getTabbableNodes } from './utils/DOMutils';
 
@@ -29,6 +30,7 @@ export {
   focusNextElement,
   focusPrevElement,
   getRelativeFocusable,
+  captureFocusRestore,
 };
 
 /**

--- a/src/return-focus.ts
+++ b/src/return-focus.ts
@@ -1,0 +1,105 @@
+import { getTabbableNodes } from './utils/DOMutils';
+
+type SetRef = () => Element | null;
+type Ref = null | (() => Element | null);
+
+type ElementLocation = {
+  current: SetRef;
+  parent: Ref;
+  left: Ref;
+  right: Ref;
+};
+
+function weakRef(value: Element): SetRef;
+function weakRef(value: Element | null): null | Ref;
+function weakRef(value: Element | null): SetRef | Ref | null {
+  if (!value) return null;
+
+  const w = value ? new WeakRef(value) : null;
+
+  return () => w?.deref() || null;
+}
+
+type Location = {
+  stack: ReadonlyArray<ElementLocation>;
+  ownerDocument: Document;
+  element: SetRef;
+};
+
+export const recordElementLocation = (element: Element): Location => {
+  const stack: ElementLocation[] = [];
+  let currentElement: Element | null = element;
+
+  while (currentElement) {
+    stack.push({
+      current: weakRef(currentElement),
+      parent: weakRef(currentElement.parentElement),
+      left: weakRef(currentElement.previousElementSibling),
+      right: weakRef(currentElement.nextElementSibling),
+    });
+
+    currentElement = currentElement.parentElement;
+  }
+
+  return {
+    element: weakRef(element),
+    stack,
+    ownerDocument: element.ownerDocument,
+  };
+};
+
+const restoreFocusTo = (location: Location): Element | undefined => {
+  const { stack, ownerDocument } = location;
+  const visibilityCache = new Map();
+
+  for (const line of stack) {
+    const parent = line.parent?.();
+
+    // is it still here?
+    if (parent && ownerDocument.contains(parent)) {
+      const left = line.left?.();
+      const right = line.right?.();
+      const focusables = getTabbableNodes([parent], visibilityCache);
+      let aim =
+        // that is element itself
+        left?.nextElementSibling ??
+        // or somebody to the right?
+        right ??
+        // or somebody to the left
+        left;
+
+      while (aim) {
+        for (const focusable of focusables) {
+          if (aim?.contains(focusable.node)) {
+            return focusable.node;
+          }
+        }
+
+        aim = aim.nextElementSibling;
+      }
+
+      if (focusables.length) {
+        // if parent contains a focusable - move there
+        return focusables[0].node;
+      }
+    }
+  }
+
+  // nothing matched
+  return undefined;
+};
+
+/**
+ * Captures the current focused element to restore focus as close as possible in the future
+ * Handles situations where the focused element is removed from the DOM or no longer focusable
+ * moving focus to the closest focusable element
+ * @param targetElement - element where focus should be restored
+ * @returns a function returning a new element to focus
+ */
+export const captureFocusRestore = (targetElement: Element): (() => Element | undefined) => {
+  const location = recordElementLocation(targetElement);
+
+  return () => {
+    return restoreFocusTo(location);
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,16 @@
     "importHelpers": true,
     "target": "es6",
     "moduleResolution": "node",
-    "lib": ["dom", "es5", "scripthost", "es2015.collection", "es2015.symbol", "es2015.iterable", "es2015.promise"],
+    "lib": [
+      "dom",
+      "es5",
+      "scripthost",
+      "es2015.collection",
+      "es2015.symbol",
+      "es2015.iterable",
+      "es2015.promise",
+      "ES2021.WeakRef"
+    ],
     "types": ["node", "jest"],
     "typeRoots": ["./node_modules/@types"],
     "jsx": "react"


### PR DESCRIPTION
Solves two cases:
- when a pointer to "return focus to node" causes a memory leak
  - uses WeakRef to store a reference
- when the target node is removed
  - finds another node to work with  