### PR TITLE
fix: remove visibility check from expandFocusableNodes

### DIFF
--- a/src/focusables.ts
+++ b/src/focusables.ts
@@ -1,7 +1,8 @@
-import { getTabbableNodes } from './utils/DOMutils';
 import { getAllAffectedNodes } from './utils/all-affected';
 import { isGuard, isNotAGuard } from './utils/is';
 import { getTopCommonParent } from './utils/parenting';
+import { orderByTabIndex } from './utils/tabOrder';
+import { getFocusables } from './utils/tabUtils';
 
 interface FocusableNode {
   node: HTMLElement;
@@ -28,11 +29,8 @@ interface FocusableNode {
 export const expandFocusableNodes = (topNode: HTMLElement | HTMLElement[]): FocusableNode[] => {
   const entries = getAllAffectedNodes(topNode).filter(isNotAGuard);
   const commonParent = getTopCommonParent(topNode, topNode, entries);
-  const visibilityCache = new Map();
-  const outerNodes = getTabbableNodes([commonParent], visibilityCache, true);
-  const innerElements = getTabbableNodes(entries, visibilityCache)
-    .filter(({ node }) => isNotAGuard(node))
-    .map(({ node }) => node);
+  const outerNodes = orderByTabIndex(getFocusables([commonParent], true), true, true);
+  const innerElements = getFocusables(entries, false);
 
   return outerNodes.map(
     ({ node, index }): FocusableNode => ({

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -33,6 +33,9 @@ const isTopNode = (node: Element): boolean =>
 
 const isInert = (node: Element): boolean => node.hasAttribute('inert');
 
+/**
+ * @see https://github.com/testing-library/jest-dom/blob/main/src/to-be-visible.js
+ */
 const isVisibleUncached = (node: Element | undefined, checkParent: CheckParentCallback): boolean =>
   !node || isTopNode(node) || (!isElementHidden(node) && !isInert(node) && checkParent(getParentNode(node)));
 


### PR DESCRIPTION
Solves performance problem for large interfaces by skipping unnecessary check