### PR TITLE
fix: focus fighting priority

### DIFF
--- a/src/moveFocusInside.ts
+++ b/src/moveFocusInside.ts
@@ -42,7 +42,7 @@ export const moveFocusInside = (topNode: HTMLElement, lastNode: Element, options
 
       setTimeout(() => {
         lockDisabled = false;
-      }, 1);
+      }, 2);
 
       return;
     }


### PR DESCRIPTION
This issue originated from the Focus Fighting.

The simplest [demo](https://codesandbox.io/p/devbox/9qtp4t) is shown below, and you can reproduce this issue in [react-focus-lock stories/FocusFighting.js](https://github.com/theKashey/react-focus-lock/blob/master/stories/FocusFighting.js) as well.

```js
function App() {
  const ref = useRef<HTMLInputElement>(null);

  return (
    <Fragment>
      <div style={{ background: "#eee", marginTop: 10, padding: 10 }}>
        <span>WorkSpace</span>
        <FocusLock autoFocus>
          <input type="text" onFocus={() => console.log("Lock input 1")} />
          <input type="text" onFocus={() => console.log("Lock input 2")} />
        </FocusLock>
      </div>
      <input
        autoFocus
        ref={ref}
        onBlur={() => ref.current?.focus()}
        onFocus={() => console.log("Lock input 3")}
      />
    </Fragment>
  );
}
```

When focus-stealing occurs, the conflict is detected but not actually prevented. You can see from the console output that the focus is still being taken over continuously. It seems like the async operation successfully steals the focus, which can affect behaviors like IME input.

<img src="https://github.com/user-attachments/assets/51c70452-3e6c-4256-b894-3ee0e597443e" width="600px" >

I believe this is caused by the priority of asynchronous tasks. Here, the [deferAction](https://github.com/theKashey/react-focus-lock/blob/master/src/util.js#L1) is setTimeout(x, 1), which doesn't wait for all callbacks to complete. This releases the lock, leading to constant contention.

So here I changed the setTimeout time to 2ms. Our goal has never been to actually delay but to adjust the priority. Calling element.focus() directly is a synchronous task, so the asynchronous lock has to wait for all previous asynchronous tasks to complete.

<img src="https://github.com/user-attachments/assets/841b4a0f-7183-4130-8cdb-5175b8588230" width="600px" >


